### PR TITLE
feat: S3 key를 URL로 변환하는 기능 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ API_KEY=your-api-key-here
 # Server Configuration
 HOST=0.0.0.0
 PORT=8000
+
+# S3 Configuration (for file download)
+# Backend sends S3 key (e.g., "uploads/2026/01/xxx.png")
+# AI server converts to full URL: S3_BASE_URL + "/" + s3_key
+S3_BASE_URL=https://your-bucket.s3.ap-northeast-2.amazonaws.com

--- a/app/schemas/text_extract.py
+++ b/app/schemas/text_extract.py
@@ -19,8 +19,8 @@ class DocumentInput(BaseModel):
     file_id: int | None = Field(None, description="파일 ID (파일 업로드 시)", example=23)
     s3_key: str | None = Field(
         None,
-        description="S3 파일 URL 또는 키 (파일 업로드 시)",
-        example="https://bucket.s3.amazonaws.com/users/12/resume/abc123.pdf",
+        description="S3 파일 키 또는 URL (예: 'uploads/2026/01/xxx.png' 또는 'https://...')",
+        example="uploads/2026/01/9eb3907b-xxx.pdf",
     )
     file_type: str | None = Field(
         None,
@@ -134,19 +134,19 @@ class TextExtractRequest(BaseModel):
         json_schema_extra = {
             "examples": [
                 {
-                    "name": "파일 업로드 방식",
+                    "name": "파일 업로드 방식 (S3 key)",
                     "value": {
                         "model": "gemini",
                         "room_id": 23,
                         "user_id": 12,
                         "resume": {
                             "file_id": 23,
-                            "s3_key": "https://bucket.s3.amazonaws.com/users/12/resume/abc123.pdf",
+                            "s3_key": "uploads/2026/01/9eb3907b-resume.pdf",
                             "file_type": "application/pdf",
                         },
                         "job_posting": {
                             "file_id": 24,
-                            "s3_key": "https://bucket.s3.amazonaws.com/users/12/job_posting/def456.png",
+                            "s3_key": "uploads/2026/01/abc123-job_posting.png",
                             "file_type": "image/png",
                         },
                     },
@@ -166,14 +166,14 @@ class TextExtractRequest(BaseModel):
                     },
                 },
                 {
-                    "name": "혼합 방식",
+                    "name": "혼합 방식 (S3 key + 텍스트)",
                     "value": {
                         "model": "gemini",
                         "room_id": 23,
                         "user_id": 12,
                         "resume": {
                             "file_id": 23,
-                            "s3_key": "https://bucket.s3.amazonaws.com/users/12/resume/abc123.pdf",
+                            "s3_key": "uploads/2026/01/9eb3907b-resume.pdf",
                             "file_type": "application/pdf",
                         },
                         "job_posting": {

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -500,7 +500,15 @@ JSON 형식으로 질문을 제공해주세요:
             raise
 
     async def _download_file(self, file_url: str) -> bytes:
-        """Download file from URL"""
+        """Download file from URL or S3 key
+
+        Supports:
+        - data: URLs (base64 encoded)
+        - http(s):// URLs (direct download)
+        - S3 keys (e.g., "uploads/2026/01/xxx.png") - converted to URL using S3_BASE_URL
+        """
+        import os
+
         # Handle data: URL
         if file_url.startswith("data:"):
             try:
@@ -512,11 +520,28 @@ JSON 형식으로 질문을 제공해주세요:
                 logger.error(f"Failed to decode data URL: {e}")
                 raise ValueError("Invalid data URL format") from e
 
-        # HTTP(S) URL
-        async with httpx.AsyncClient() as client:
-            response = await client.get(file_url, timeout=30.0)
-            response.raise_for_status()
-            return response.content
+        # Handle HTTP(S) URL (direct download)
+        if file_url.startswith("http://") or file_url.startswith("https://"):
+            async with httpx.AsyncClient() as client:
+                response = await client.get(file_url, timeout=30.0)
+                response.raise_for_status()
+                return response.content
+
+        # Handle S3 key (convert to full URL)
+        # e.g., "uploads/2026/01/xxx.png" → "https://bucket.s3.amazonaws.com/uploads/2026/01/xxx.png"
+        s3_base_url = os.getenv("S3_BASE_URL", "").rstrip("/")
+        if s3_base_url:
+            full_url = f"{s3_base_url}/{file_url.lstrip('/')}"
+            logger.info(f"Converting S3 key to URL: {file_url[:50]}... → {full_url[:80]}...")
+            async with httpx.AsyncClient() as client:
+                response = await client.get(full_url, timeout=30.0)
+                response.raise_for_status()
+                return response.content
+
+        # S3_BASE_URL not configured and not a valid URL
+        raise ValueError(
+            f"Cannot download file: S3_BASE_URL not configured and '{file_url[:50]}...' is not a valid URL"
+        )
 
     def _pdf_to_images(self, pdf_bytes: bytes, dpi: int = 200) -> list[Image.Image]:
         """Convert PDF to images"""


### PR DESCRIPTION
백엔드에서 S3 key 형태로 파일 경로를 전달하면 AI 서버에서
S3_BASE_URL과 조합하여 완전한 URL로 변환 후 다운로드

변경 사항:
- .env.example: S3_BASE_URL 환경변수 추가
- llm_service.py: _download_file()에 S3 key 변환 로직 추가
- vllm_service.py: _download_file()에 S3 key 변환 로직 추가
- text_extract.py: s3_key 필드 설명 및 예시 업데이트

지원하는 입력 형식:
- S3 key: "uploads/2026/01/xxx.png"
- HTTP(S) URL: "https://..."
- data: URL (base64)

## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
