### PR TITLE
refactor: task_id를 백엔드에서 전달받도록 변경

### DIFF
--- a/app/api/routes/ai.py
+++ b/app/api/routes/ai.py
@@ -44,15 +44,8 @@ router = APIRouter(
 )
 
 # 임시 작업 저장소 (실제로는 Redis 등 사용)
+# 백엔드에서 전달받은 task_id를 키로 사용하여 인메모리에 임시 보관
 tasks_db = {}
-task_id_counter = 0  # 정수 task_id 카운터
-
-
-def get_next_task_id() -> int:
-    """Get next task_id as integer"""
-    global task_id_counter
-    task_id_counter += 1
-    return task_id_counter
 
 
 # Initialize services
@@ -257,7 +250,7 @@ async def verify_api_key(x_api_key: str | None = Header(None)):
 )
 async def text_extract(request: TextExtractRequest):
     """텍스트 추출 + 임베딩 저장 (통합) - 이력서 + 채용공고"""
-    task_id = get_next_task_id()
+    task_id = request.task_id  # 백엔드에서 전달받은 task_id 사용
 
     # 비동기 작업 시작
     tasks_db[task_id] = {

--- a/app/schemas/text_extract.py
+++ b/app/schemas/text_extract.py
@@ -115,6 +115,7 @@ class TextExtractRequest(BaseModel):
     각 문서는 파일 업로드 또는 텍스트 입력 중 하나의 방식으로 제공됩니다.
     """
 
+    task_id: int = Field(..., description="작업 ID (백엔드에서 생성)", example=1)
     room_id: int = Field(..., description="채팅방 ID", example=23)
     user_id: int = Field(..., description="사용자 ID", example=12)
     resume: DocumentInput = Field(..., description="이력서/포트폴리오 입력")
@@ -136,6 +137,7 @@ class TextExtractRequest(BaseModel):
                 {
                     "name": "파일 업로드 방식 (S3 key)",
                     "value": {
+                        "task_id": 1,
                         "model": "gemini",
                         "room_id": 23,
                         "user_id": 12,
@@ -154,6 +156,7 @@ class TextExtractRequest(BaseModel):
                 {
                     "name": "텍스트 직접 입력 방식",
                     "value": {
+                        "task_id": 2,
                         "model": "gemini",
                         "room_id": 23,
                         "user_id": 12,
@@ -168,6 +171,7 @@ class TextExtractRequest(BaseModel):
                 {
                     "name": "혼합 방식 (S3 key + 텍스트)",
                     "value": {
+                        "task_id": 3,
                         "model": "gemini",
                         "room_id": 23,
                         "user_id": 12,


### PR DESCRIPTION
- TextExtractRequest에 task_id 필드 추가 (백엔드에서 생성)
- FastAPI 내부 task_id 생성 로직 제거 (task_id_counter, get_next_task_id)
- 백엔드에서 전달받은 task_id를 인메모리에 임시 보관

## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
