### PR TITLE
fix: Allow s3_key and text simultaneously, prioritize s3_key

### DIFF
--- a/app/schemas/text_extract.py
+++ b/app/schemas/text_extract.py
@@ -35,16 +35,16 @@ class DocumentInput(BaseModel):
 
     @validator("text", always=True)
     def validate_input_source(cls, v, values):
-        """s3_key 또는 text 중 하나는 필수"""
+        """s3_key 또는 text 중 하나는 필수 (둘 다 있으면 s3_key 우선)"""
         s3_key = values.get("s3_key")
 
         # 둘 다 없으면 에러
         if not v and not s3_key:
             raise ValueError("s3_key 또는 text 중 하나는 필수입니다")
 
-        # 둘 다 있으면 에러
+        # 둘 다 있으면 s3_key 우선, text는 무시
         if v and s3_key:
-            raise ValueError("s3_key와 text를 동시에 사용할 수 없습니다")
+            return None  # s3_key가 있으면 text는 무시
 
         return v
 


### PR DESCRIPTION
- Modified DocumentInput validator to accept both s3_key and text
- When both are present, s3_key takes priority and text is set to None
- Fixes 422 error when backend sends both fields
- Backend no longer needs to conditionally set text to null

## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
