### PR TITLE
Potential fix for code scanning alert no. 135: Log Injection

### DIFF
--- a/app/api/routes/v1/masking.py
+++ b/app/api/routes/v1/masking.py
@@ -22,7 +22,7 @@ from app.schemas.masking import (
 )
 from app.services.chandra_masking import get_chandra_masking_service
 from app.services.gemini_masking import get_gemini_masking_service
-from app.utils.log_sanitizer import sanitize_log_input
+from app.utils.log_sanitizer import safe_info, safe_warning
 
 logger = logging.getLogger(__name__)
 
@@ -205,16 +205,15 @@ async def get_masking_task_status(
     task_storage=Depends(get_legacy_task_storage),
 ):
     """마스킹 작업 상태 조회"""
-    safe_task_id = sanitize_log_input(task_id)
     task = task_storage.get(task_id)
     if task is None:
-        logger.warning("[GET_STATUS] Task not found: %s", safe_task_id)
+        safe_warning(logger, "[GET_STATUS] Task not found: %s", task_id)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"code": ErrorCode.TASK_NOT_FOUND, "message": "작업을 찾을 수 없습니다."},
         )
 
-    logger.info("[GET_STATUS] Task %s status: %s", safe_task_id, task["status"])
+    safe_info(logger, "[GET_STATUS] Task %s status: %s", task_id, task["status"])
 
     return TaskStatusResponse(
         task_id=task_id,


### PR DESCRIPTION
Potential fix for [https://github.com/100-hours-a-week/9-team-Devths-AI/security/code-scanning/135](https://github.com/100-hours-a-week/9-team-Devths-AI/security/code-scanning/135)

General fix strategy: ensure that any user-controlled data passed into logging APIs is sanitized immediately before logging, using a function that removes CR/LF and control characters, and use that sanitizer consistently at the logging call sites.

Best concrete fix here without changing functionality:

- In `app/utils/log_sanitizer.py`, the `safe_warning`/`safe_info` wrappers already sanitize all arguments before calling `logger.log`.
- In `app/api/routes/v1/masking.py`, replace direct calls to `logger.warning` and `logger.info` for `task_id` with calls to `safe_warning` and `safe_info`, and pass the raw `task_id` instead of pre-sanitizing into `safe_task_id`. This avoids double-sanitization, simplifies the route code, and ensures the sanitizer is applied right at the sink.
- Remove the now-unused `safe_task_id` local variable to keep the code clean.

Concretely:

- In `app/api/routes/v1/masking.py`:
  - Change the import `from app.utils.log_sanitizer import sanitize_log_input` to also import `safe_warning` and `safe_info` (and keep `sanitize_log_input` if it’s used elsewhere in this file; from the snippet, it’s only used here, so we can remove it).
  - In `get_masking_task_status`, remove `safe_task_id = sanitize_log_input(task_id)`.
  - Replace `logger.warning("[GET_STATUS] Task not found: %s", safe_task_id)` with `safe_warning(logger, "[GET_STATUS] Task not found: %s", task_id)`.
  - Replace `logger.info("[GET_STATUS] Task %s status: %s", safe_task_id, task["status"])` with `safe_info(logger, "[GET_STATUS] Task %s status: %s", task_id, task["status"])`.

This keeps the runtime behavior essentially the same (user-supplied IDs are still sanitized before being logged) but makes the log-safety explicit at the call site in a way that static analysis tools will more easily understand.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
