### PR TITLE
fix(langfuse): Langfuse 토큰 사용량 기록

### DIFF
--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -133,6 +133,32 @@ class LLMService:
             # Langfuse 오류로 본 서비스가 죽지 않게 방어
             return
 
+    @staticmethod
+    def _to_langfuse_usage_details(usage_metadata: Any | None) -> dict[str, int] | None:
+        """Gemini usage_metadata -> Langfuse usage_details 변환.
+
+        Langfuse v3의 generation observation은 `usage_details={"prompt_tokens": int, "completion_tokens": int, ...}`
+        형태를 지원합니다.
+        """
+        if usage_metadata is None:
+            return None
+        try:
+            prompt_tokens = int(getattr(usage_metadata, "prompt_token_count", 0) or 0)
+            completion_tokens = int(getattr(usage_metadata, "candidates_token_count", 0) or 0)
+            total_tokens = int(
+                getattr(usage_metadata, "total_token_count", 0)
+                or (prompt_tokens + completion_tokens)
+            )
+            if prompt_tokens <= 0 and completion_tokens <= 0 and total_tokens <= 0:
+                return None
+            return {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+            }
+        except Exception:
+            return None
+
     def _record_token_usage(self, response: Any, model_name: str) -> None:
         """CloudWatch에 토큰 사용량 기록"""
         try:
@@ -256,12 +282,22 @@ class LLMService:
                     response = client.models.generate_content_stream(
                         model=self.model_name, contents=contents, config=config
                     )
+                    last_chunk: Any | None = None
                     for chunk in response:
+                        last_chunk = chunk
                         if hasattr(chunk, "text") and chunk.text:
                             full_response += chunk.text
                             yield chunk.text
-                    self._record_token_usage(response, self.model_name)
+                    if last_chunk is not None:
+                        self._record_token_usage(last_chunk, self.model_name)
                     if trace is not None:
+                        usage_details = (
+                            self._to_langfuse_usage_details(
+                                getattr(last_chunk, "usage_metadata", None)
+                            )
+                            if last_chunk is not None
+                            else None
+                        )
                         create_generation(
                             trace=trace,
                             name="gemini_stream",
@@ -269,6 +305,7 @@ class LLMService:
                             input_text=final_message_for_trace,
                             output_text=full_response,
                             metadata={"streaming": True},
+                            usage_details=usage_details,
                         )
                     return
                 except Exception as e:
@@ -385,6 +422,9 @@ class LLMService:
 
             # Langfuse generation 기록
             if trace is not None:
+                usage_details = self._to_langfuse_usage_details(
+                    getattr(response, "usage_metadata", None)
+                )
                 create_generation(
                     trace=trace,
                     name="gemini_non_stream",
@@ -392,6 +432,7 @@ class LLMService:
                     input_text=final_message,
                     output_text=result_text,
                     metadata={"streaming": False},
+                    usage_details=usage_details,
                 )
 
             return result_text

--- a/app/utils/langfuse_client.py
+++ b/app/utils/langfuse_client.py
@@ -4,6 +4,7 @@ Langfuse 클라이언트 유틸리티
 Langfuse를 사용하여 LLM 호출을 추적하고 모니터링합니다.
 """
 
+import contextlib
 import logging
 import os
 from typing import Any, TypedDict
@@ -117,6 +118,7 @@ def create_generation(
     input_text: str,
     output_text: str | None = None,
     metadata: dict | None = None,
+    usage_details: dict[str, int] | None = None,
 ):
     """
     Generation 생성 (LLM 호출 기록)
@@ -128,6 +130,7 @@ def create_generation(
         input_text: 입력 텍스트
         output_text: 출력 텍스트 (선택)
         metadata: 추가 메타데이터 (선택)
+        usage_details: 토큰 사용량 (선택) - Langfuse v3 `usage_details` 형식
 
     Returns:
         Langfuse generation 객체 또는 None
@@ -139,21 +142,47 @@ def create_generation(
         client = trace["client"]
         trace_id = trace["trace_id"]
 
-        generation = client.start_generation(
-            name=name,
-            trace_context={"trace_id": trace_id},
-            model=model,
-            input=input_text,
-            output=output_text,
-            metadata=metadata or {},
-        )
+        # Langfuse SDK v3에서는 start_observation(as_type="generation", usage_details=...) 사용을 권장.
+        # 하위 호환을 위해 start_observation이 없거나 실패하면 start_generation로 fallback.
+        generation = None
+        if hasattr(client, "start_observation"):
+            try:
+                generation = client.start_observation(
+                    name=name,
+                    as_type="generation",
+                    trace_context={"trace_id": trace_id},
+                    model=model,
+                    input=input_text,
+                    output=output_text,
+                    metadata=metadata or {},
+                    usage_details=usage_details,
+                )
+            except TypeError:
+                # 일부 버전에서 usage_details 시그니처가 다를 수 있어 fallback
+                generation = None
+
+        if generation is None:
+            generation = client.start_generation(
+                name=name,
+                trace_context={"trace_id": trace_id},
+                model=model,
+                input=input_text,
+                output=output_text,
+                metadata=metadata or {},
+            )
+            # start_generation 경로에서도 update()가 지원되면 usage_details를 반영
+            if usage_details and hasattr(generation, "update"):
+                with contextlib.suppress(Exception):
+                    generation.update(usage_details=usage_details)
         # trace 메타/유저 정보 업데이트
-        generation.update_trace(
-            name=trace.get("trace_name"),
-            user_id=trace.get("user_id"),
-            metadata=trace.get("metadata") or {},
-        )
-        generation.end()
+        if hasattr(generation, "update_trace"):
+            generation.update_trace(
+                name=trace.get("trace_name"),
+                user_id=trace.get("user_id"),
+                metadata=trace.get("metadata") or {},
+            )
+        if hasattr(generation, "end"):
+            generation.end()
         return generation
     except Exception as e:
         logger.error(f"Failed to create Langfuse generation: {e}")


### PR DESCRIPTION
## 작업한 내용
- Langfuse generation에 `usage_details`(prompt/completion/total tokens)를 기록하도록 계측 추가
- Gemini 비스트리밍/스트리밍 모두에서 usage_metadata를 추출해 Langfuse로 전달
- 스트리밍 경로에서 CloudWatch 토큰 기록도 마지막 chunk 기준으로 정리

## 참고 사항
- Gemini 스트리밍 응답이 usage_metadata를 제공하지 않는 경우가 있어, 해당 경우 `usage_details`는 기록되지 않을 수 있습니다.
- Langfuse SDK 버전 차이를 고려해 `start_observation(as_type=\"generation\")` 우선 사용 후, 불가 시 `start_generation()` + `update()`로 fallback 처리했습니다.

## 테스트 계획
- [x] Ruff lint 통과 (`poetry run ruff check app/`)
- [x] Ruff format 통과 (`poetry run ruff format --check app/`)
- [x] Python import 검증 통과 (`poetry run python -c \"import app.main; print('Import OK')\"`)

Made with [Cursor](https://cursor.com)