### PR TITLE
fix: CORS allow_origins=* + credentials 조합 수정 및 JudgeService 503 에러 처리

### DIFF
--- a/app/api/routes/v2/evaluation.py
+++ b/app/api/routes/v2/evaluation.py
@@ -552,6 +552,18 @@ async def judge_single_response(request: JudgeRequest) -> JudgeResponse:
 
     try:
         judge = JudgeService()
+    except ValueError as e:
+        # GOOGLE_API_KEY / GEMINI_API_KEY 미설정 — 서비스 자체가 사용 불가
+        logger.warning("JudgeService 초기화 실패 (API 키 미설정): %s", str(e))
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "JUDGE_UNAVAILABLE",
+                "message": "Judge LLM 서비스가 설정되지 않았습니다. GOOGLE_API_KEY 환경변수를 확인하세요.",
+            },
+        ) from e
+
+    try:
         result = await judge.score(
             question=request.question,
             answer=request.answer,

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -54,6 +54,18 @@ class Settings(BaseSettings):
     api_port: int = Field(default=8000, description="API port")
 
     # ============================================
+    # CORS
+    # ============================================
+    allowed_origins: list[str] = Field(
+        default=["http://localhost:3000", "http://localhost:5173"],
+        description=(
+            "CORS 허용 origin 목록. "
+            "환경변수 ALLOWED_ORIGINS=https://dev.devths.com,http://localhost:3000 처럼 "
+            "쉼표 구분 문자열로도 입력 가능."
+        ),
+    )
+
+    # ============================================
     # Google Gemini API
     # ============================================
     google_api_key: str | None = Field(

--- a/app/main.py
+++ b/app/main.py
@@ -98,9 +98,12 @@ app = FastAPI(
 )
 
 # CORS 미들웨어 설정
+# allow_origins=["*"] + allow_credentials=True 조합은 CORS 명세 위반
+# (Starlette는 쿠키 없는 요청에서 * 와 credentials:true를 동시 반환 → 브라우저 차단)
+# → settings.allowed_origins 로 구체적 도메인 관리 (환경변수 ALLOWED_ORIGINS)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION

## 📌 작업한 내용
- main.py: allow_origins=["*"] + allow_credentials=True 는 CORS 명세 위반 (Starlette 0.49.3: 쿠키 없는 요청에서 * + credentials:true 동시 반환 → 브라우저 차단) → settings.allowed_origins 로 구체적 도메인 관리 (환경변수 ALLOWED_ORIGINS)
- settings.py: allowed_origins 필드 추가 (기본값: localhost:3000/5173)
- evaluation.py: JudgeService() 초기화 ValueError (GOOGLE_API_KEY 미설정) → 500 Internal Server Error 대신 503 Service Unavailable 반환
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
