### PR TITLE
fix: 헬스체크 타임아웃 120초로 연장 및 실패 로그 가시성 개선

### DIFF
--- a/deploy/docker_deploy.sh
+++ b/deploy/docker_deploy.sh
@@ -225,9 +225,9 @@ fi
 
 log "✅ All services started successfully."
 
-# 7. Health Check
-log "🏥 Health Checking..."
-for i in {1..12}; do
+# 7. Health Check (24 × 5s = 120초 대기 — 새 ML 서비스 기동 여유)
+log "🏥 Health Checking (up to 120s)..."
+for i in {1..24}; do
     sleep 5
     if curl -s "http://localhost:8000/health" > /dev/null; then
         log "✅ Health check passed!"
@@ -235,8 +235,8 @@ for i in {1..12}; do
         # 8. Trigger Auto-Embedding if flagged by CI/CD
         if [ "$TRIGGER_DATA_EMBEDDING" = "true" ]; then
             log "📂 Data directory change detected. Triggering auto-embedding..."
-            docker exec ai-service python scripts/auto_embed_data.py >> "$LOG_FILE" 2>&1
-            if [ $? -eq 0 ]; then
+            docker exec ai-service python scripts/auto_embed_data.py 2>&1 | tee -a "$LOG_FILE"
+            if [ ${PIPESTATUS[0]} -eq 0 ]; then
                 log "✅ Auto-embedding completed successfully."
             else
                 log "⚠️  Auto-embedding failed! Check the logs above."
@@ -246,9 +246,9 @@ for i in {1..12}; do
         log "🚀 Deployment Successful!"
         exit 0
     fi
-    log "⏳ Waiting for service to be healthy... ($i/12)"
+    log "⏳ Waiting for service to be healthy... ($i/24)"
 done
 
-log "❌ Health check timed out! Showing recent container logs:"
-docker compose -f "$COMPOSE_FILE" logs --tail 30 ai-endpoint >> "$LOG_FILE" 2>&1
+log "❌ Health check timed out! Dumping ai-endpoint logs:"
+docker compose -f "$COMPOSE_FILE" logs --tail 50 ai-endpoint 2>&1 | tee -a "$LOG_FILE"
 exit 1


### PR DESCRIPTION
## Summary
- 헬스체크 대기 시간 **60초 → 120초** 연장 (`{1..12}` × 5s → `{1..24}` × 5s)
- 타임아웃 시 `ai-endpoint` 컨테이너 로그 50줄을 `tee -a` 로 CodeDeploy 콘솔에 직접 출력
- auto-embedding 실행 로그도 `>>` → `tee -a` 전환

## Why
`52a83fa` (PR #199) 머지 후 배포가 여전히 실패 (`d-YE02ZQY5H`).
`docker compose up`은 성공한 것으로 추정 (진단 덤프가 출력되지 않음).
새 ML 서비스(RAPTOR, SemanticChunker) 추가로 Gunicorn 기동 시간이 길어졌을 가능성.
또한 타임아웃 발생 시 컨테이너 로그가 파일에만 저장되어 실패 원인 파악 불가 → `tee` 전환.

## Test plan
- [ ] PR 머지 후 develop CI/CD 배포 트리거
- [ ] GitHub Actions 로그에 `✅ Health check passed!` 또는 타임아웃 시 ai-endpoint 로그 50줄 출력 확인
- [ ] CodeDeploy `deploymentInfo.status: Succeeded` 확인