### PR TITLE
fix: ChromaDB where 필터 정규화로 면접 기능 오류 수정

### DIFF
--- a/app/domain/chat/chains.py
+++ b/app/domain/chat/chains.py
@@ -16,6 +16,7 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 from app.infrastructure.llm.langchain_wrapper import LangChainLLMGateway
+from app.utils.chromadb_utils import normalize_chromadb_filter
 from app.utils.langfuse_client import get_langfuse_callback_handler
 
 logger = logging.getLogger(__name__)
@@ -147,12 +148,13 @@ class RAGChain:
     ) -> list[tuple[str, Document]]:
         """Run MMR search on one collection (sync method in thread)."""
         try:
+            effective_filter = normalize_chromadb_filter(filter_dict)
             docs = store.max_marginal_relevance_search(
                 query,
                 k=self._retrieval_k,
                 fetch_k=self._fetch_k,
                 lambda_mult=self._lambda_mult,
-                filter=filter_dict,
+                filter=effective_filter,
             )
             return [(collection_type, doc) for doc in docs]
         except Exception as e:
@@ -180,6 +182,7 @@ class RAGChain:
                 store = self._vectorstores.get(ct)
                 if not store:
                     continue
+                # user_id가 있고 portfolio가 아닌 경우에만 필터 적용
                 filter_dict = None
                 if ct != "portfolio" and user_id:
                     filter_dict = {"user_id": user_id}
@@ -192,13 +195,14 @@ class RAGChain:
                 )
                 all_pairs.extend(pairs)
         elif self._vectorstore:
+            # normalize_chromadb_filter로 user_id 정규화
+            effective_filter = normalize_chromadb_filter({"user_id": user_id}) if user_id else None
+            filter_kwargs: dict[str, Any] = {"score_threshold": 0.3, "k": self._retrieval_k}
+            if effective_filter:
+                filter_kwargs["filter"] = effective_filter
             retriever = self._vectorstore.as_retriever(
                 search_type="similarity_score_threshold",
-                search_kwargs={
-                    "score_threshold": 0.3,
-                    "k": self._retrieval_k,
-                    "filter": {"user_id": user_id},
-                },
+                search_kwargs=filter_kwargs,
             )
             docs = await retriever.aget_relevant_documents(query)
             for doc in docs:

--- a/app/services/vectordb_service.py
+++ b/app/services/vectordb_service.py
@@ -20,6 +20,7 @@ from langchain_google_genai import GoogleGenerativeAIEmbeddings
 
 from app.config.settings import get_settings
 from app.services.text_splitter_service import TextChunk, TextSplitterService
+from app.utils.chromadb_utils import normalize_chromadb_filter
 
 logger = logging.getLogger(__name__)
 
@@ -485,11 +486,13 @@ class VectorDBService:
 
             start_time = time.perf_counter()
 
+            effective_where = normalize_chromadb_filter(where)
+
             # Query collection
             results = collection.query(
                 query_embeddings=[query_embedding],
                 n_results=n_results,
-                where=where,
+                where=effective_where,
                 include=["documents", "metadatas", "distances"],
             )
 
@@ -553,8 +556,8 @@ class VectorDBService:
         try:
             collection = self._get_collection(collection_type)
 
-            # Get all documents with matching user_id
-            result = collection.get(where={"user_id": user_id}, include=["documents", "metadatas"])
+            where_filter = normalize_chromadb_filter({"user_id": user_id})
+            result = collection.get(where=where_filter, include=["documents", "metadatas"])
 
             formatted_results = []
             if result and result["ids"] and len(result["ids"]) > 0:

--- a/app/utils/chromadb_utils.py
+++ b/app/utils/chromadb_utils.py
@@ -1,0 +1,37 @@
+"""
+ChromaDB 유틸리티 함수
+
+ChromaDB where 필터 정규화 등 공통 로직을 제공합니다.
+"""
+
+from typing import Any
+
+
+def normalize_chromadb_filter(where: dict[str, Any] | None) -> dict[str, Any] | None:
+    """ChromaDB where 필터 정규화.
+
+    - None이거나 빈 딕셔너리면 None 반환
+    - user_id는 문자열로 변환 (ChromaDB 메타데이터는 문자열로 저장됨)
+    - 빈 문자열 값은 제외
+
+    Args:
+        where: ChromaDB where 필터 딕셔너리
+
+    Returns:
+        정규화된 필터 딕셔너리 또는 None
+    """
+    if not where:
+        return None
+
+    normalized: dict[str, Any] = {}
+    for k, v in where.items():
+        if v is None:
+            continue
+        if k == "user_id":
+            v_str = str(v).strip()
+            if v_str:
+                normalized[k] = v_str
+        else:
+            normalized[k] = v
+
+    return normalized or None


### PR DESCRIPTION
## 작업한 내용
- ChromaDB `where` 필터가 빈 딕셔너리 `{}`일 때 발생하는 `InvalidArgumentError` 수정
- `user_id`가 정수형일 때 문자열 메타데이터와 타입 불일치 문제 해결
- 공통 유틸리티 함수 `normalize_chromadb_filter()` 추가로 중복 코드 제거

## 참고 사항
- 면접 시작 시 MMR 검색에서 `Expected where document to have exactly one operator, got {}` 에러 발생하던 문제 해결
- `user_id`를 문자열로 일관되게 변환하여 ChromaDB 메타데이터와 타입 일치
- 빈 문자열 `user_id`도 `None`으로 처리하여 엣지 케이스 방어

## 테스트 계획
- [x] Ruff lint 통과 (`poetry run ruff check app/`)
- [x] Ruff format 통과 (`poetry run ruff format --check app/`)
- [x] Python import 검증 통과
- [ ] 기술면접/인성면접 시작 테스트
- [ ] OCR 후 분석 리포트 생성 테스트

Made with [Cursor](https://cursor.com)