### PR TITLE
refactor: Gemini 모델 마이그레이션 및 하드코딩 제거

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -74,7 +74,7 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("GOOGLE_API_KEY", "GEMINI_API_KEY"),
     )
     gemini_model: str = Field(
-        default="gemini-3.1-flash-preview",
+        default="gemini-3-flash-preview",
         description="Gemini model name",
     )
     gemini_embedding_model: str = Field(


### PR DESCRIPTION
## Summary

- **Gemini Pro 마이그레이션**: `gemini-3-pro-preview` → `gemini-3.1-pro-preview` (Google 2026-03-09 지원 종료)
- **Flash 모델 복구**: `gemini-3.1-flash-preview`(존재하지 않는 모델) → `gemini-3-flash-preview` (404 오류 수정)
- **하드코딩 제거**: 모든 서비스 레이어의 모델명 하드코딩을 `get_settings()` 참조로 통일
- **PHASE 1 로그 개선**: 시작/완료 로그에 `user_id`/`room_id` 포함, `safe_info()` Log Injection 방어 적용

## Changed Files

| 파일 | 변경 내용 |
|------|----------|
| `app/config/settings.py` | `eval_gemini_model` → `gemini-3.1-pro-preview`, `gemini_model` → `gemini-3-flash-preview` |
| `app/services/llm_service.py` | `self._settings.gemini_model` 참조로 교체 |
| `app/services/calendar_parsing.py` | `get_settings().gemini_model` 참조로 교체 |
| `app/services/gemini_masking.py` | `get_settings().gemini_model` 참조로 교체 |
| `app/services/judge_service.py` | docstring 모델명 업데이트 |
| `app/domain/evaluation/analyzer.py` | `model_name: str \| None = None` + `get_settings().eval_gemini_model` |
| `app/domain/evaluation/debate_graph.py` | `gemini_model: str \| None = None` + `get_settings().eval_gemini_model` (함수·클래스 2곳) |
| `app/infrastructure/llm/langchain_wrapper.py` | `model_name: str \| None = None` + `get_settings().gemini_model` |
| `app/api/routes/v2/chat.py` | PHASE 1 시작/완료 로그에 `safe_info()` 적용, `full_response` 할당 복구 |

## Test plan

- [ ] 서버 기동 후 `gemini-3-flash-preview` 모델로 채용공고 분석 정상 동작 확인 (404 오류 없음)
- [ ] 면접 평가 시 `gemini-3.1-pro-preview` 모델 사용 확인
- [ ] 면접 PHASE 1 시작/완료 로그에 `user_id`/`room_id` 포함 여부 확인
- [ ] 환경 변수 미설정 시 `settings.py` 기본값 사용 확인