### PR TITLE
fix: 인성 면접 LLM 완전 스킵 + 꼬리질문 비활성화

### DIFF
--- a/app/api/routes/v2/chat.py
+++ b/app/api/routes/v2/chat.py
@@ -642,9 +642,9 @@ async def generate_chat_stream(
                                 request.user_id,
                                 request.room_id,
                             )
-                        except BaseException:
-                            llm_task.cancel()
-                            raise
+                        finally:
+                            if not llm_task.done():
+                                llm_task.cancel()
 
                 # JSON 파싱 또는 vectordb 직접 구성
                 try:


### PR DESCRIPTION
## Summary

- **PHASE 1**: 인성 면접에서 LLM API 호출 전에 VectorDB pre-fetch → 성공 시 LLM 완전 스킵 (~15초 절약)
- **PHASE 2**: 인성 면접에서 꼬리질문(follow-up) 없이 Q1→Q2→Q3→Q4→Q5 순서로 자동 진행
- 기술 면접은 기존 LLM 호출 + 꼬리질문 동작 유지

## 변경 내용

### PHASE 1 — LLM 스킵 (`chat.py` lines 554–648)

LLM 호출 전 `interview_feedback` VectorDB에서 인성 질문 4개 선 조회:

```python
behavior_questions_data: dict | None = None
if interview_type == "behavior":
    _fb = await rag.vectordb.query(
        query_text="인성 면접 질문",
        collection_type="interview_feedback",
        n_results=4,
        where={"interview_type": "personality"},
    )
    if len(_fb_qs) >= 4:
        logger.info("✅ interview_feedback 인성 질문 %d개 → LLM 스킵", len(_fb_qs))
        behavior_questions_data = {"questions": [_fixed_q1] + _fb_qs[:4]}

full_response = ""  # 기본값
if behavior_questions_data is None:
    # 기존 LLM 호출 코드 (tech 면접 + behavior 폴백)
    ...
```

JSON 파싱 블록도 리팩토링 — vectordb/LLM 양방향 처리:
```python
if behavior_questions_data is not None:
    questions_data = behavior_questions_data  # vectordb 직접 사용
else:
    questions_data = json.loads(llm_response)  # LLM 파싱
# 공통: 세션 생성 + 스트리밍 + 저장
```

### PHASE 2 — 꼬리질문 비활성화 (`chat.py` lines 777–781)

```python
# 변경 전
if current_q.current_depth < current_q.max_depth:
    followup_prompt = create_tech_followup_prompt(...)

# 변경 후
if interview_type == "behavior":
    logger.info("📋 [인성 면접] 꼬리질문 스킵 → Q%s 완료", current_q_id)
    current_q.is_completed = True
elif current_q.current_depth < current_q.max_depth:
    followup_prompt = create_tech_followup_prompt(...)
```

## 기대 동작

```
# 인성 면접 (behavior):
✅ interview_feedback 인성 질문 4개 → LLM 스킵   ← PHASE 1 로그
✅ 면접 질문 세트 생성 완료: 5개
📋 [인성 면접] 꼬리질문 스킵 → Q1 완료          ← PHASE 2 로그
→ 바로 Q2 질문 스트리밍
→ 소요 시간: ~3-4초 (기존 15-16초 → 80% 단축)

# 기술 면접 (tech): 변경 없음
```

## Test plan

- [ ] 인성 면접 시작 시 서버 로그에 `✅ interview_feedback 인성 질문 4개 → LLM 스킵` 출력 확인
- [ ] Q1 답변 후 `📋 [인성 면접] 꼬리질문 스킵 → Q1 완료` 로그 + Q2 즉시 스트리밍 확인
- [ ] 기술 면접은 LLM 호출 + 꼬리질문 기존 동작 그대로 확인
- [ ] VectorDB 결과 부족 시 LLM 폴백 동작 확인 (로그: `interview_feedback 선 조회 실패 → LLM 폴백`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)