### PR TITLE
fix(session): 파일 기반 폴백 추가 — 서버 재시작 후 면접 세션 복원

### DIFF
--- a/app/infrastructure/session/redis.py
+++ b/app/infrastructure/session/redis.py
@@ -5,6 +5,7 @@ Implements the BaseSessionStore interface with Redis backend.
 Used for production environments with distributed systems.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -75,9 +76,8 @@ class RedisSessionStore(BaseSessionStore):
         try:
             if not os.path.exists(_PERSIST_FILE):
                 return
-            with self._file_lock:
-                with open(_PERSIST_FILE, "r", encoding="utf-8") as f:
-                    raw: dict[str, Any] = json.load(f)
+            with self._file_lock, open(_PERSIST_FILE, encoding="utf-8") as f:
+                raw: dict[str, Any] = json.load(f)
             now = time.time()
             valid = {
                 k: v["data"]
@@ -91,15 +91,22 @@ class RedisSessionStore(BaseSessionStore):
             logger.warning("파일 폴백 로드 실패 (무시): %s", e)
 
     def _save_file_fallback(self, key: str, value: dict[str, Any]) -> None:
-        """세션을 파일에 저장 (서버 재시작 대비)."""
+        """세션을 파일에 저장 (서버 재시작 대비). 만료 항목 동시 정리."""
         try:
             with self._file_lock:
                 try:
-                    with open(_PERSIST_FILE, "r", encoding="utf-8") as f:
+                    with open(_PERSIST_FILE, encoding="utf-8") as f:
                         raw: dict[str, Any] = json.load(f)
                 except (FileNotFoundError, json.JSONDecodeError):
                     raw = {}
-                raw[key] = {"data": value, "ts": time.time()}
+                # 저장 시 만료 항목 정리 — 파일 무한 증가 방지
+                now = time.time()
+                raw = {
+                    k: v
+                    for k, v in raw.items()
+                    if isinstance(v, dict) and now - v.get("ts", 0) < _PERSIST_TTL
+                }
+                raw[key] = {"data": value, "ts": now}
                 with open(_PERSIST_FILE, "w", encoding="utf-8") as f:
                     json.dump(raw, f, ensure_ascii=False)
         except Exception as e:
@@ -110,7 +117,7 @@ class RedisSessionStore(BaseSessionStore):
         try:
             with self._file_lock:
                 try:
-                    with open(_PERSIST_FILE, "r", encoding="utf-8") as f:
+                    with open(_PERSIST_FILE, encoding="utf-8") as f:
                         raw: dict[str, Any] = json.load(f)
                 except (FileNotFoundError, json.JSONDecodeError):
                     return
@@ -169,8 +176,8 @@ class RedisSessionStore(BaseSessionStore):
             if fallback:
                 logger.warning("Redis 장애 — 메모리 폴백으로 세션 복원: %s", safe_key)
                 return fallback
-            # 2단계: 파일 폴백 (서버 재시작 후 메모리가 비어 있을 때)
-            self._load_file_fallback()
+            # 2단계: 파일 폴백 (서버 재시작 후 메모리가 비어 있을 때) — 별도 스레드로 비블로킹
+            await asyncio.to_thread(self._load_file_fallback)
             fallback = self._fallback.get(key)
             if fallback:
                 logger.warning("Redis 장애 — 파일 폴백으로 세션 복원 (재시작 후): %s", safe_key)
@@ -191,7 +198,8 @@ class RedisSessionStore(BaseSessionStore):
         """
         # 폴백 먼저 저장 (항상 성공 — Redis 장애 및 재시작에도 세션 보존)
         self._fallback[key] = value
-        self._save_file_fallback(key, value)  # 파일 폴백 저장 (재시작 대비)
+        # 파일 폴백 저장 — 이벤트 루프 비블로킹 (스레드 풀에서 실행)
+        asyncio.get_running_loop().run_in_executor(None, self._save_file_fallback, key, value)
         try:
             ttl_seconds = ttl if ttl is not None else self._default_ttl
             data = json.dumps(value)
@@ -219,7 +227,8 @@ class RedisSessionStore(BaseSessionStore):
             True if deleted, False if not found.
         """
         self._fallback.pop(key, None)  # 메모리 폴백에서 삭제
-        self._delete_file_fallback(key)  # 파일 폴백에서도 삭제
+        # 파일 폴백 삭제 — 이벤트 루프 비블로킹 (스레드 풀에서 실행)
+        asyncio.get_running_loop().run_in_executor(None, self._delete_file_fallback, key)
         try:
             result = await self._redis.delete(self._make_key(key))
             if result > 0:


### PR DESCRIPTION
## Summary

- **근본 원인**: Redis 장애 + 서버 재시작(배포/코드 리로드) → in-memory 폴백 초기화 → 면접 세션 소멸 → PHASE 1 재실행 → Q1 "자기소개" 반복
- **해결**: `/tmp/devths_interview_sessions.json` 파일 기반 폴백으로 재시작 후에도 세션 복원

## 폴백 3단계 구조

```
GET 시 조회 순서:
  1. Redis (정상 시)
  2. in-memory fallback (Redis 장애 시, 동일 프로세스)
  3. 파일 기반 fallback (서버 재시작 후 메모리가 비어 있을 때) ← 신규
```

## 변경 내용 (`app/infrastructure/session/redis.py`)

### 초기화 시 파일에서 세션 복원
```python
def _load_file_fallback(self) -> None:
    # /tmp/devths_interview_sessions.json 파일에서 2시간 이내 세션 복원
    # → 서버 재시작 직후에도 진행 중인 면접 세션 유지
```

### SET 시 파일에 저장
```python
self._save_file_fallback(key, value)  # 재시작 대비 파일 저장
```

### GET 실패 시 파일에서 복원
```python
# Redis 장애 + 메모리 없음 → 파일 폴백 재로드
self._load_file_fallback()
fallback = self._fallback.get(key)
```

## 기대 동작

```
# 서버 재시작 전:
💾 [면접] 세션 저장: interview:18:219 (파일에도 저장)

# 서버 재시작 후 (초기화 로그):
📂 파일 폴백에서 세션 2개 복원 (재시작 후 복구)

# Q2 답변 처리:
Redis 장애 — 파일 폴백으로 세션 복원 (재시작 후): interview:18:219
📦 [면접] 캐시에서 세션 복원: interview:18:219, phase=questioning, Q2/5
→ Q3 질문 스트리밍 ✅ (Q1 반복 없음)
```

## Test plan

- [ ] 인성 면접 Q1 답변 후 서버 강제 재시작 → Q2 답변 시 Q1이 아닌 Q2 진행 확인
- [ ] `/tmp/devths_interview_sessions.json` 파일 생성 및 세션 저장 확인
- [ ] 서버 시작 로그에 `📂 파일 폴백에서 세션 N개 복원` 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)