### PR TITLE
chore: 배포 스크립트 강제 삭제 오류 및 헬스체크 완화 수정 (#232)

### DIFF
--- a/deploy/docker_deploy.sh
+++ b/deploy/docker_deploy.sh
@@ -182,21 +182,11 @@ log "✅ Pre-flight check passed."
 # 5. Stop existing services (if any)
 log "🛑 Stopping existing services..."
 
-# [마이그레이션 정리] 이전 docker run 기반 컨테이너 강제 삭제
-# docker compose down은 docker run으로 시작된 컨테이너를 인식하지 못해
-# container_name 충돌로 compose up이 실패하는 것을 방지
-log "🧹 Removing legacy containers (docker run → docker compose migration)..."
-LEGACY_NAMES=("ai-service" "ai-promtail" "celery_worker_trend" "celery_worker_extract" "celery_beat")
-for name in "${LEGACY_NAMES[@]}"; do
-    if docker ps -aq --filter "name=^${name}$" | grep -q .; then
-        docker rm -f "$name" 2>&1 | tee -a "$LOG_FILE"
-        if [ ${PIPESTATUS[0]} -eq 0 ]; then
-            log "   🗑️  Removed legacy container: $name"
-        else
-            log "   ⚠️  Failed to remove legacy container: $name (continuing anyway)"
-        fi
-    fi
-done
+# [마이그레이션 정리] 기존 컨테이너 정리 로직 수정
+# docker compose down이 이전 배포 버전의 컨테이너를 Graceful(SIGTERM)하게 꺼줍니다.
+# 잔여 고아(Orphan) 컨테이너 및 죽은(Exited) 컨테이너만 정리합니다.
+log "🧹 Removing legacy or orphaned containers..."
+docker container prune -f 2>&1 | tee -a "$LOG_FILE"
 
 if [ -f "$COMPOSE_FILE" ]; then
     docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" down --remove-orphans 2>&1 | tee -a "$LOG_FILE"

--- a/deploy/validate_service.sh
+++ b/deploy/validate_service.sh
@@ -38,9 +38,9 @@ done
 
 for CNAME in "${OPTIONAL_CONTAINERS[@]}"; do
     if docker ps --format '{{.Names}}' | grep -q "^$CNAME$"; then
-        echo "   ✅ $CNAME is running. (optional)"
+        echo "   ✅ $CNAME is running. (optional/monitoring)"
     else
-        echo "   ⚠️  $CNAME is not running. (optional — monitoring may be unavailable)"
+        echo "   ⚠️  $CNAME is not running. (Monitoring logs will not be sent to Loki)"
     fi
 done
 


### PR DESCRIPTION


## 📌 작업한 내용

- docker_deploy.sh: docker run 잔재 삭제 로직(docker rm -f)을 삭제하고 docker container prune 으로 대체하여 운영 컨테이너 강제 종료 버그 수정
- validate_service.sh: 선택적 모니터링 컨테이너(promtail) 부재 시 배포가 실패하지 않도록 로깅 문구만 출력하도록 개선
 
## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

closes: #232 

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
