### PR TITLE
feat: SageMaker 학습 데이터 동기화 Celery 태스크 추가 (ADR-117)

### DIFF
--- a/app/tasks/sagemaker_sync_tasks.py
+++ b/app/tasks/sagemaker_sync_tasks.py
@@ -18,8 +18,6 @@ import os
 import re
 from datetime import datetime
 
-import boto3
-
 from app.tasks.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -106,6 +104,8 @@ def _extract_collection_data(vectordb, collection_type: str) -> list[dict]:
 
 def _upload_to_s3(records: list[dict], collection_type: str, timestamp: str) -> str:
     """학습 데이터를 JSONL 형식으로 S3에 업로드."""
+    import boto3
+
     s3_client = boto3.client("s3", region_name=AWS_REGION)
 
     s3_key = f"{S3_TRAINING_DATA_PREFIX}{timestamp}/{collection_type}.jsonl"
@@ -213,6 +213,8 @@ def trigger_sagemaker_pipeline_task(self, s3_data_path: str = ""):
     logger.info("[SageMakerSync] SageMaker Pipeline 트리거: %s", SAGEMAKER_PIPELINE_NAME)
 
     try:
+        import boto3
+
         sm_client = boto3.client("sagemaker", region_name=AWS_REGION)
 
         params = []


### PR DESCRIPTION
## 작업한 내용
- VectorDB(ChromaDB) → S3 학습 데이터 동기화 Celery 태스크 추가 (`sagemaker_sync_tasks.py`)
- `sync_training_data_task`: trend_data, interview_feedback 컬렉션 데이터 추출 → 익명화(PII 마스킹) → JSONL 변환 → S3 업로드
- `trigger_sagemaker_pipeline_task`: S3 업로드 완료 후 SageMaker Pipeline 자동 트리거
- `celery_app.py`에 새 태스크 모듈 등록, `sagemaker_sync` 큐 라우팅, Beat 스케줄 추가
- Beat 스케줄: 트렌드 크롤링 1시간 후 자동 실행 (cron hour overflow 방지 `% 24` 적용)
- boto3 lazy import 적용 (Docker 이미지에 boto3 미설치 시에도 Celery 워커 정상 기동)

## 참고 사항
- ADR-117 (SageMaker Pipelines 채택) 설계에 따른 데이터 흐름 구현
- 기존 `trend_tasks.py`와 동일한 패턴 (Celery task → async wrapper → service 호출)
- 환경변수: `SAGEMAKER_S3_BUCKET`, `SAGEMAKER_S3_TRAINING_PREFIX`, `SAGEMAKER_PIPELINE_NAME`, `AWS_REGION`
- boto3는 태스크 실행 시에만 필요 (lazy import). 향후 pyproject.toml 의존성 추가 권장

## 테스트 계획
- [x] Ruff lint 통과
- [x] Ruff format 통과
- [x] Python import 검증 통과
- [ ] 기능 동작 테스트 완료