### PR TITLE
feat: SSE 클라이언트 연결 해제 감지 + Polling 힌트 추가 (AI 백엔드 고도화)

### DIFF
--- a/app/api/routes/v2/chat.py
+++ b/app/api/routes/v2/chat.py
@@ -11,7 +11,7 @@ import random
 import time
 import uuid
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
 
 from app.api.routes.v2._helpers import (
@@ -65,6 +65,7 @@ router = APIRouter()
 async def generate_chat_stream(
     request: ChatRequest,
     session_store,
+    http_request: Request,
 ):
     """채팅 응답 스트리밍 생성 (session_store: DI from get_session_store)"""
 
@@ -278,6 +279,9 @@ async def generate_chat_stream(
                             history=[],
                             system_prompt="당신은 채용 전문가입니다. 마크다운 문법(#, ##, **, ```)을 절대 사용하지 말고 일반 텍스트로만 응답하세요.",
                         ):
+                            if await http_request.is_disconnected():
+                                logger.info("[Chat][NORMAL] 클라이언트 연결 해제 — 스트림 종료")
+                                return
                             record_ttft()
                             full_response += chunk
                             yield f"data: {json.dumps({'chunk': chunk}, ensure_ascii=False)}{sse_end}"
@@ -303,6 +307,9 @@ async def generate_chat_stream(
                         model="gemini",
                         chat_mode=mode.value if hasattr(mode, "value") else str(mode),  # ADR-077
                     ):
+                        if await http_request.is_disconnected():
+                            logger.info("[Chat][NORMAL] 클라이언트 연결 해제 — 스트림 종료")
+                            return
                         record_ttft()
                         full_response += chunk
                         yield f"data: {json.dumps({'chunk': chunk}, ensure_ascii=False)}{sse_end}"
@@ -350,6 +357,9 @@ async def generate_chat_stream(
                             system_prompt="당신은 전문 면접관입니다. 지원자의 답변을 평가하고 구체적인 피드백을 제공합니다. 마크다운 문법을 사용하지 마세요.",
                             user_id=request.user_id,
                         ):
+                            if await http_request.is_disconnected():
+                                logger.info("[Chat][NORMAL] 클라이언트 연결 해제 — 스트림 종료")
+                                return
                             record_ttft()
                             full_response += chunk
                             yield f"data: {json.dumps({'chunk': chunk}, ensure_ascii=False)}{sse_end}"
@@ -381,6 +391,9 @@ async def generate_chat_stream(
                             model=model,
                             user_id=request.user_id,
                         ):
+                            if await http_request.is_disconnected():
+                                logger.info("[Chat][NORMAL] 클라이언트 연결 해제 — 스트림 종료")
+                                return
                             record_ttft()
                             full_response += chunk
                             yield f"data: {json.dumps({'chunk': chunk}, ensure_ascii=False)}{sse_end}"
@@ -411,12 +424,18 @@ async def generate_chat_stream(
                         model=model,
                         chat_mode=mode.value if hasattr(mode, "value") else str(mode),  # ADR-077
                     ):
+                        if await http_request.is_disconnected():
+                            logger.info("[Chat][NORMAL] 클라이언트 연결 해제 — 스트림 종료")
+                            return
                         record_ttft()
                         full_response += chunk
                         yield f"data: {json.dumps({'chunk': chunk}, ensure_ascii=False)}{sse_end}"
 
                     logger.info("✅ 일반 대화 완료 (응답 길이: %d자)", len(full_response))
 
+        except asyncio.CancelledError:
+            logger.info("[Chat][NORMAL] 스트림 취소됨 (클라이언트 연결 해제)")
+            return
         except Exception as e:
             logger.error("채팅 처리 오류: %s", str(e), exc_info=True)
             yield sse_error_event(
@@ -436,6 +455,9 @@ async def generate_chat_stream(
         try:
             # SSE 스트림 즉시 오픈: Redis/RAG 등 첫 await 전에 keepalive를 전송해
             # 프록시(Nginx) 및 메인 백엔드의 첫 청크 대기 타임아웃을 방지한다.
+            if await http_request.is_disconnected():
+                logger.info("[Chat][INTERVIEW] 클라이언트 연결 해제 — 스트림 종료")
+                return
             yield ": keepalive\n\n"
 
             interview_type = request.context.interview_type or "tech"
@@ -804,6 +826,9 @@ async def generate_chat_stream(
                             f"{format_main_question_label(1)}{newline}{first_q.question}"
                         )
                         async for chunk in stream_text_chars(question_text, sse_end):
+                            if await http_request.is_disconnected():
+                                logger.info("[Chat][INTERVIEW] 클라이언트 연결 해제 — 스트림 종료")
+                                return
                             yield chunk
 
                         session_meta = {
@@ -882,6 +907,9 @@ async def generate_chat_stream(
                         current_q.current_depth,
                         current_q.max_depth,
                     )
+                    if await http_request.is_disconnected():
+                        logger.info("[Chat][INTERVIEW] 클라이언트 연결 해제 — 스트림 종료")
+                        return
                     yield ": keepalive\n\n"
 
                     if model_choice == "vllm" and rag.vllm:
@@ -891,6 +919,9 @@ async def generate_chat_stream(
                             history=[],
                             system_prompt=system_prompt,
                         ):
+                            if await http_request.is_disconnected():
+                                logger.info("[Chat][INTERVIEW] 클라이언트 연결 해제 — 스트림 종료")
+                                return
                             record_ttft()
                             full_response += chunk
                             yield ": k\n\n"
@@ -902,6 +933,9 @@ async def generate_chat_stream(
                             system_prompt=system_prompt,
                             user_id=request.user_id,
                         ):
+                            if await http_request.is_disconnected():
+                                logger.info("[Chat][INTERVIEW] 클라이언트 연결 해제 — 스트림 종료")
+                                return
                             record_ttft()
                             full_response += chunk
                             yield ": k\n\n"
@@ -951,6 +985,9 @@ async def generate_chat_stream(
                                 )
                                 followup_text = f"{followup_header}{newline}{followup_q}"
                                 async for chunk in stream_text_chars(followup_text, sse_end):
+                                    if await http_request.is_disconnected():
+                                        logger.info("[Chat][INTERVIEW] 클라이언트 연결 해제 — 스트림 종료")
+                                        return
                                     yield chunk
                             else:
                                 safe_info(
@@ -1005,6 +1042,9 @@ async def generate_chat_stream(
                             question_header = format_main_question_label(next_q_id)
                             question_text = f"{question_header}{newline}{next_q.question}"
                             async for chunk in stream_text_chars(question_text, sse_end):
+                                if await http_request.is_disconnected():
+                                    logger.info("[Chat][INTERVIEW] 클라이언트 연결 해제 — 스트림 종료")
+                                    return
                                 yield chunk
 
                             next_q.conversation.append(
@@ -1017,6 +1057,9 @@ async def generate_chat_stream(
                         session.phase = "completed"
                         complete_msg = f"{newline}{newline}면접 결과 리포트를 생성 중입니다. 잠시만 기다려 주세요."
                         async for chunk in stream_text_chars(complete_msg, sse_end):
+                            if await http_request.is_disconnected():
+                                logger.info("[Chat][INTERVIEW] 클라이언트 연결 해제 — 스트림 종료")
+                                return
                             yield chunk
 
                 await session_store.set(session_key, session.model_dump())
@@ -1046,6 +1089,9 @@ async def generate_chat_stream(
                 yield f"data: {json.dumps({'chunk': complete_msg}, ensure_ascii=False)}{sse_end}"
                 yield f"data: [DONE]{sse_end}"
 
+        except asyncio.CancelledError:
+            logger.info("[Chat][INTERVIEW] 스트림 취소됨 (클라이언트 연결 해제)")
+            return
         except Exception as e:
             logger.error(f"Interview error: {e}", exc_info=True)
             yield sse_error_event(
@@ -1161,11 +1207,12 @@ async def generate_chat_stream(
 )
 async def chat(
     request: ChatRequest,
+    http_request: Request,
     session_store=Depends(get_session_store),
 ):
     """채팅 처리 (일반/면접)"""
     return StreamingResponse(
-        generate_chat_stream(request, session_store),
+        generate_chat_stream(request, session_store, http_request),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/app/api/routes/v2/evaluation.py
+++ b/app/api/routes/v2/evaluation.py
@@ -15,7 +15,7 @@ import asyncio
 import json
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from app.api.routes.v2._helpers import get_services
@@ -102,7 +102,7 @@ def _trigger_ingest_interview_qa(request: AnalyzeInterviewRequest):
 # ============================================
 
 
-async def _generate_analyze_stream(request: AnalyzeInterviewRequest):
+async def _generate_analyze_stream(request: AnalyzeInterviewRequest, http_request: Request):
     """면접 평가 리포트 SSE 스트리밍 생성 (Gemini 단독)."""
     sse_end = "\n\n"
     qa_list = request.context or []
@@ -169,6 +169,9 @@ async def _generate_analyze_stream(request: AnalyzeInterviewRequest):
                 history=[],
                 system_prompt=_REPORT_SYSTEM_PROMPT,
             ):
+                if await http_request.is_disconnected():
+                    logger.info("[Evaluation] 클라이언트 연결 해제 — 스트림 종료")
+                    return
                 full_report += chunk
                 yield f"data: {json.dumps({'chunk': chunk}, ensure_ascii=False)}{sse_end}"
         else:
@@ -180,6 +183,9 @@ async def _generate_analyze_stream(request: AnalyzeInterviewRequest):
                 system_prompt=_REPORT_SYSTEM_PROMPT,
                 user_id=request.user_id,
             ):
+                if await http_request.is_disconnected():
+                    logger.info("[Evaluation] 클라이언트 연결 해제 — 스트림 종료")
+                    return
                 full_report += chunk
                 yield f"data: {json.dumps({'chunk': chunk}, ensure_ascii=False)}{sse_end}"
 
@@ -188,6 +194,9 @@ async def _generate_analyze_stream(request: AnalyzeInterviewRequest):
         # ADR-102: 면접 Q&A 데이터를 Celery 태스크로 VectorDB에 저장
         _trigger_ingest_interview_qa(request)
 
+    except asyncio.CancelledError:
+        logger.info("[Evaluation] 스트림 취소됨 (클라이언트 연결 해제)")
+        return
     except ConnectionError as e:
         logger.error("LLM 서비스 연결 실패: %s", str(e), exc_info=True)
         fallback_msg = "AI 서비스에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."
@@ -253,6 +262,7 @@ async def _generate_debate_stream(
     request: AnalyzeInterviewRequest,
     analyzer: InterviewAnalyzer,
     debate_service: DebateService,
+    http_request: Request,
 ):
     """Gemini×GPT-4o 토론 후 최종 리포트 SSE 스트리밍 생성."""
     sse_end = "\n\n"
@@ -295,6 +305,9 @@ async def _generate_debate_stream(
 
     # ── 1단계: Gemini 구조화 분석 ──
     try:
+        if await http_request.is_disconnected():
+            logger.info("[Debate] 클라이언트 연결 해제 — 스트림 종료")
+            return
         progress = "🔍 Gemini 분석 중...\n"
         yield f"data: {json.dumps({'chunk': progress}, ensure_ascii=False)}{sse_end}"
 
@@ -303,6 +316,9 @@ async def _generate_debate_stream(
         gemini_dict = gemini_result.to_dict()
         logger.info("✅ [Debate] 1단계 완료: overall_score=%d", gemini_result.overall_score)
 
+    except asyncio.CancelledError:
+        logger.info("[Debate] 스트림 취소됨 (클라이언트 연결 해제)")
+        return
     except Exception as e:
         logger.error("Gemini 분석 실패: %s", str(e), exc_info=True)
         fallback_msg = "Gemini 분석 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
@@ -317,6 +333,9 @@ async def _generate_debate_stream(
 
     # ── 2단계: Gemini×GPT-4o 토론 ──
     try:
+        if await http_request.is_disconnected():
+            logger.info("[Debate] 클라이언트 연결 해제 — 스트림 종료")
+            return
         progress = "🤖 GPT-4o 심층 분석 및 토론 중...\n"
         yield f"data: {json.dumps({'chunk': progress}, ensure_ascii=False)}{sse_end}"
 
@@ -339,6 +358,9 @@ async def _generate_debate_stream(
 
         logger.info("✅ [Debate] 최종 리포트 스트리밍 완료")
 
+    except asyncio.CancelledError:
+        logger.info("[Debate] 스트림 취소됨 (클라이언트 연결 해제)")
+        return
     except Exception as e:
         logger.error("Debate 토론 실패: %s", str(e), exc_info=True)
 
@@ -462,6 +484,7 @@ async def _generate_debate_stream(
 )
 async def analyze_interview(
     request: AnalyzeInterviewRequest,
+    http_request: Request,
     analyzer: InterviewAnalyzer = Depends(get_evaluation_analyzer),
     debate_service: DebateService | None = Depends(get_debate_service),
 ):
@@ -480,20 +503,20 @@ async def analyze_interview(
         if not debate_service:
             logger.warning("Debate service unavailable, falling back to Gemini-only")
             return StreamingResponse(
-                _generate_analyze_stream(request),
+                _generate_analyze_stream(request, http_request),
                 media_type="text/event-stream",
                 headers=sse_headers,
             )
 
         return StreamingResponse(
-            _generate_debate_stream(request, analyzer, debate_service),
+            _generate_debate_stream(request, analyzer, debate_service, http_request),
             media_type="text/event-stream",
             headers=sse_headers,
         )
 
     # retry=false → Gemini 단독 분석
     return StreamingResponse(
-        _generate_analyze_stream(request),
+        _generate_analyze_stream(request, http_request),
         media_type="text/event-stream",
         headers=sse_headers,
     )

--- a/app/api/routes/v2/masking.py
+++ b/app/api/routes/v2/masking.py
@@ -129,7 +129,7 @@ async def masking_draft(
     return AsyncTaskResponse(
         task_id=task_id,
         status=TaskStatus.PROCESSING,
-        message="마스킹 작업을 시작했습니다. /ai/task/{task_id}로 진행 상태를 확인하세요.",
+        message=f"마스킹 작업을 시작했습니다. /ai/task/{task_id}로 진행 상태를 확인하세요.",
         polling=PollingHint(interval_ms=2000, max_attempts=150),  # 최대 5분(150 × 2초)
     )
 

--- a/app/api/routes/v2/masking.py
+++ b/app/api/routes/v2/masking.py
@@ -17,7 +17,13 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.config.dependencies import get_legacy_task_storage
-from app.schemas.common import AsyncTaskResponse, ErrorCode, TaskStatus, TaskStatusResponse
+from app.schemas.common import (
+    AsyncTaskResponse,
+    ErrorCode,
+    PollingHint,
+    TaskStatus,
+    TaskStatusResponse,
+)
 from app.schemas.masking import MaskingDraftRequest
 from app.services.chandra_masking import get_chandra_masking_service
 from app.services.gemini_masking import get_gemini_masking_service
@@ -124,6 +130,7 @@ async def masking_draft(
         task_id=task_id,
         status=TaskStatus.PROCESSING,
         message="마스킹 작업을 시작했습니다. /ai/task/{task_id}로 진행 상태를 확인하세요.",
+        polling=PollingHint(interval_ms=2000, max_attempts=150),  # 최대 5분(150 × 2초)
     )
 
 

--- a/app/api/routes/v2/text_extract.py
+++ b/app/api/routes/v2/text_extract.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, status
 
 from app.config.dependencies import get_legacy_task_storage
-from app.schemas.common import AsyncTaskResponse, TaskStatus
+from app.schemas.common import AsyncTaskResponse, PollingHint, TaskStatus
 from app.schemas.text_extract import TextExtractRequest
 
 logger = logging.getLogger(__name__)
@@ -232,4 +232,8 @@ async def text_extract(
             safe_task_key,
         )
 
-    return AsyncTaskResponse(task_id=task_id, status=TaskStatus.PROCESSING)
+    return AsyncTaskResponse(
+        task_id=task_id,
+        status=TaskStatus.PROCESSING,
+        polling=PollingHint(interval_ms=2000, max_attempts=150),  # 최대 5분(150 × 2초)
+    )

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -62,12 +62,20 @@ class TaskStatus(str, Enum):
     FAILED = "failed"
 
 
+class PollingHint(BaseModel):
+    """폴링 힌트 — 클라이언트 폴링 간격 및 최대 횟수 권장치"""
+
+    interval_ms: int = Field(..., description="권장 폴링 간격 (밀리초)")
+    max_attempts: int = Field(..., description="최대 폴링 횟수 (초과 시 타임아웃 처리 권장)")
+
+
 class AsyncTaskResponse(BaseModel):
     """비동기 작업 초기 응답"""
 
     task_id: str | int = Field(..., description="작업 ID (text_extract: int, masking: str)")
     status: TaskStatus = Field(TaskStatus.PROCESSING, description="작업 상태")
     message: str | None = Field(None, description="상태 메시지")
+    polling: PollingHint | None = Field(None, description="클라이언트 폴링 힌트 (interval_ms, max_attempts)")
 
 
 class TaskStatusResponse(BaseModel):


### PR DESCRIPTION
## Summary

- **SSE 클라이언트 연결 해제 감지**: `chat.py`, `evaluation.py`에서 `request.is_disconnected()` + `asyncio.CancelledError` 두 메커니즘 병행 적용 — 클라이언트가 끊기면 즉시 LLM 스트림 생성 중단
- **Polling 힌트 추가**: `text_extract.py`, `masking.py`의 202 응답에 `PollingHint(interval_ms=2000, max_attempts=150)` 포함 — 클라이언트가 최적 주기로 폴링 가능
- **f-string 버그 수정**: `masking.py`의 `message` 필드에 `f` 접두사 누락되어 `{task_id}`가 문자열 그대로 반환되던 버그 수정
- **ADR 문서화**: ADR-127(SSE 연결 해제 감지), ADR-128(Polling 힌트) 작성

## Changes

### `app/schemas/common.py`
- `PollingHint` Pydantic 모델 추가 (`interval_ms`, `max_attempts`)
- `AsyncTaskResponse`에 `polling: PollingHint | None` 필드 추가

### `app/api/routes/v2/chat.py`
- `generate_chat_stream()`, `chat()` 함수에 `http_request: Request` 파라미터 추가
- NORMAL 모드 LLM 루프 5개 + INTERVIEW 모드 루프 내 disconnect 체크 추가
- `asyncio.CancelledError` 핸들러 2개 추가 (ASGI 태스크 취소 대응)

### `app/api/routes/v2/evaluation.py`
- `_generate_analyze_stream()`, `_generate_debate_stream()` 함수에 `http_request: Request` 추가
- vLLM/Gemini 루프 각 단계 시작 전 disconnect 체크 + `CancelledError` 핸들러 추가

### `app/api/routes/v2/text_extract.py`, `masking.py`
- 202 응답에 `polling=PollingHint(interval_ms=2000, max_attempts=150)` 추가
- `masking.py` f-string 버그 수정

## Test plan

- [ ] `POST /ai/chat` SSE 스트림 도중 클라이언트 강제 연결 해제 → 서버 로그에 `[Chat][NORMAL] 클라이언트 연결 해제 — 스트림 종료` 출력 확인
- [ ] `POST /ai/evaluation/analyze` SSE 스트림 도중 연결 해제 → `[Evaluation] 스트림 취소됨` 로그 확인
- [ ] `POST /ai/text-extract` 202 응답 body에 `polling.interval_ms: 2000`, `polling.max_attempts: 150` 포함 확인
- [ ] `POST /ai/masking` 202 응답 body에 `polling` 힌트 포함, `message`에 `task_id` 값 정상 치환 확인
- [ ] Swagger UI(`/docs`)에서 `AsyncTaskResponse` 스키마에 `polling` 필드 표시 확인

## Related ADRs

- ADR-127: SSE 클라이언트 연결 해제 감지
- ADR-128: Polling 힌트 (응답 바디 Pydantic 모델 방식)

🤖 Generated with [Claude Code](https://claude.com/claude-code)