### PR TITLE
feat: FileTaskStore → RedisTaskStore 마이그레이션 (k8s 멀티 파드 대응)

### DIFF
--- a/app/config/dependencies.py
+++ b/app/config/dependencies.py
@@ -182,22 +182,53 @@ def get_task_queue(
 # Legacy Task Storage (save/get dict - ai.py 호환)
 # ============================================
 
-_task_storage_instance = None
+_task_storage_instance = None        # FileTaskStore fallback 싱글톤
+_redis_task_storage_instance = None  # RedisTaskStore 싱글톤 (ADR-130)
 
 
 def get_legacy_task_storage(
     settings: Settings = Depends(get_settings),
 ):
-    """Get legacy file-based task storage (save/get dict).
+    """Task 저장소 — Redis 우선, Redis 미설정 시 파일 폴백 (ADR-130).
 
-    Used by ai.py for text_extract and task status polling.
-    Same API as utils.task_store.FileTaskStore for drop-in replacement.
+    Redis URL이 설정된 환경(dev 포함)에서는 RedisTaskStore를 반환한다.
+    Redis가 없는 순수 로컬 환경에서만 FileTaskStore로 폴백한다.
+
+    k8s 분리 Deployment(FastAPI·Celery Worker 별도 파드) 환경에서
+    /tmp 파일 공유 불가 문제를 해결하기 위해 Redis로 통일.
+
+    Note:
+        Celery 태스크에서 인수 없이 호출 시 settings = Depends(get_settings) 객체가
+        전달되므로, 싱글톤 확인을 먼저 수행해 settings 접근을 최소화한다.
     """
+    global _redis_task_storage_instance, _task_storage_instance
+
+    # ── Fast path: 싱글톤이 이미 있으면 settings 접근 없이 즉시 반환 ──────────────
+    # Celery 태스크는 인수 없이 호출하므로 settings가 Depends 객체일 수 있음.
+    # 싱글톤 확인을 먼저 수행해 AttributeError를 방지한다.
+    if _redis_task_storage_instance is not None:
+        return _redis_task_storage_instance
+    if _task_storage_instance is not None:
+        return _task_storage_instance
+
+    # ── 최초 초기화: 실제 Settings 객체 확보 ──────────────────────────────────────
+    # FastAPI DI 없이 직접 호출(Celery 등)하면 settings = Depends 마커 객체이므로
+    # get_settings()를 직접 호출해 실제 설정을 가져온다.
+    actual_settings: Settings = settings if hasattr(settings, "redis_url") else get_settings()
+
+    if actual_settings.redis_url:
+        from app.utils.task_store import RedisTaskStore
+
+        _redis_task_storage_instance = RedisTaskStore(
+            redis_url=actual_settings.redis_url,  # DB 0, prefix "legacy_task:"으로 세션과 네임스페이스 분리
+            ttl=actual_settings.redis_task_ttl,   # 기본 86400초 (24시간)
+        )
+        return _redis_task_storage_instance
+
+    # Redis 없는 순수 로컬 환경 fallback
     from app.utils.task_store import FileTaskStore
 
-    global _task_storage_instance
-    if _task_storage_instance is None:
-        _task_storage_instance = FileTaskStore(storage_dir=settings.task_storage_dir)
+    _task_storage_instance = FileTaskStore(storage_dir=actual_settings.task_storage_dir)
     return _task_storage_instance
 
 

--- a/app/utils/task_store.py
+++ b/app/utils/task_store.py
@@ -1,9 +1,9 @@
 """
-통합 파일 기반 Task 저장소
+Task 저장소 — FileTaskStore (파일 기반) + RedisTaskStore (Redis 기반)
 
-모든 비동기 작업(text_extract, masking 등)을 통합 관리
-개발 환경에서 uvicorn --reload 모드에서도 task가 유지되도록 함
-프로덕션에서는 Redis 등으로 교체 필요
+모든 비동기 작업(text_extract, masking 등)을 통합 관리.
+- FileTaskStore: 순수 로컬 환경(Redis 없음) fallback용
+- RedisTaskStore: Redis가 있는 모든 환경(dev/nonprod/prod) 기본 사용 (ADR-130)
 """
 
 import json
@@ -89,12 +89,63 @@ class FileTaskStore:
         return deleted_count
 
 
+class RedisTaskStore:
+    """Redis 기반 Task 저장소 — FileTaskStore 드롭인 교체 (ADR-130).
+
+    FileTaskStore와 동일한 save() / get() / delete() / exists() 인터페이스를 제공하여
+    호출 측 코드(text_extract.py, masking.py, task.py) 변경 없이 교체 가능.
+
+    - Redis DB 0 사용, "legacy_task:" prefix로 세션 키와 네임스페이스 분리
+    - TTL 24시간(86400초) 자동 만료 → /tmp 파일 누적 문제 해소
+    - k8s 분리 Deployment 환경에서 FastAPI·Celery Worker 간 상태 공유 지원
+    """
+
+    def __init__(self, redis_url: str, ttl: int = 86400, prefix: str = "legacy_task:"):
+        import redis as _redis
+
+        self._redis = _redis.from_url(redis_url, decode_responses=True)
+        self._ttl = ttl
+        self._prefix = prefix
+
+    def _key(self, task_id: str) -> str:
+        return f"{self._prefix}{task_id}"
+
+    def save(self, task_id: str, data: dict[str, Any]) -> None:
+        """Task 저장 (TTL 포함)"""
+        serializable = data.copy()
+        if "created_at" in serializable and isinstance(serializable["created_at"], datetime):
+            serializable["created_at"] = serializable["created_at"].isoformat()
+        self._redis.setex(
+            self._key(task_id),
+            self._ttl,
+            json.dumps(serializable, ensure_ascii=False),
+        )
+
+    def get(self, task_id: str) -> dict[str, Any] | None:
+        """Task 조회"""
+        raw = self._redis.get(self._key(task_id))
+        if raw is None:
+            return None
+        data = json.loads(raw)
+        if "created_at" in data and isinstance(data["created_at"], str):
+            data["created_at"] = datetime.fromisoformat(data["created_at"])
+        return data
+
+    def exists(self, task_id: str) -> bool:
+        """Task 존재 여부"""
+        return bool(self._redis.exists(self._key(task_id)))
+
+    def delete(self, task_id: str) -> None:
+        """Task 삭제"""
+        self._redis.delete(self._key(task_id))
+
+
 # 전역 인스턴스
 _task_store = None
 
 
 def get_task_store() -> FileTaskStore:
-    """Task Store 싱글톤"""
+    """Task Store 싱글톤 (FileTaskStore — 레거시 호환용)"""
     global _task_store
     if _task_store is None:
         _task_store = FileTaskStore()


### PR DESCRIPTION
## 작업한 내용

- **`RedisTaskStore` 클래스 추가** (`app/utils/task_store.py`)
  - `FileTaskStore`와 동일한 `save()` / `get()` / `exists()` / `delete()` 인터페이스 (드롭인 교체)
  - `"legacy_task:"` prefix로 Redis DB0 내 세션 키(`"session:"`)와 네임스페이스 분리
  - TTL 24시간(`setex`) 자동 만료 → `/tmp/ai_tasks/` 파일 누적 문제 해소

- **`get_legacy_task_storage()` Redis 분기 추가** (`app/config/dependencies.py`)
  - `redis_url` 설정 시 `RedisTaskStore` 반환 (dev/nonprod/prod 공통)
  - `redis_url` 미설정 시 `FileTaskStore` fallback (순수 로컬 환경)
  - **Fast path 싱글톤 선확인**: Celery 태스크가 인수 없이 직접 호출 시 `settings = Depends(get_settings)` 객체가 전달되어 `AttributeError`가 발생하는 잠재 버그 수정
  - `hasattr(settings, "redis_url")` 분기로 Celery 컨텍스트에서 `get_settings()` 직접 호출

- **ADR-130 작성** (`4.DOCS/1.ADR/[AI] 25_ADR_ 126-130.md`)
  - 단일 파드 멀티 컨테이너 / 분리 Deploy + PV·PVC / Redis 통일 3가지 옵션 비교 분석

## 참고 사항

- 호출 측 5개 파일(`text_extract.py`, `masking.py`, `task.py`, `ai.py` v1·v2)은 변경 없음 — 인터페이스 일치 덕분
- Redis DB 할당: DB0(세션+legacy_task) / DB1(Celery 브로커) / DB2(Celery 결과 백엔드)
- k8s 분리 Deployment 환경에서 FastAPI·Celery Worker 파드가 동일 Redis를 통해 태스크 상태 공유

## 테스트 계획

- [ ] Ruff lint 통과 (`poetry run ruff check app/`)
- [ ] Ruff format 통과 (`poetry run ruff format --check app/`)
- [ ] Python import 검증 통과
- [ ] dev 환경에서 OCR 태스크 제출 → `/ai/task/{task_id}` 폴링 정상 응답 확인
- [ ] Redis CLI로 `legacy_task:*` 키 생성·TTL 확인
- [ ] Celery Worker 로그에서 `get_legacy_task_storage()` 직접 호출 정상 동작 확인