### PR TITLE
feat: Tavily 결과 신뢰성 검증 + 최신 데이터 필터링 (ADR-131)

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -233,6 +233,31 @@ class Settings(BaseSettings):
         default=5,
         description="Tavily 검색당 최대 결과 수. ADR-101.",
     )
+    tavily_days: int = Field(
+        default=90,
+        ge=0,
+        description=(
+            "Tavily 검색 결과를 최근 N일 이내로 제한. 0이면 제한 없음. ADR-131. "
+            "예: 90 → 90일 이내 발행된 문서만 반환."
+        ),
+    )
+    tavily_min_score: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Tavily 결과 최소 relevance score (0.0~1.0). 미달 결과 제거. ADR-131. "
+            "0.0으로 설정 시 score 필터 비활성화."
+        ),
+    )
+    tavily_min_content_length: int = Field(
+        default=200,
+        ge=0,
+        description=(
+            "Tavily 결과 최소 본문 길이(문자 수). 미달 결과 제거. ADR-131. "
+            "0으로 설정 시 길이 필터 비활성화."
+        ),
+    )
     trend_crawl_queries: str = Field(
         default="",
         description=(

--- a/app/services/tavily_search_service.py
+++ b/app/services/tavily_search_service.py
@@ -1,5 +1,5 @@
 """
-Tavily Search Service — ADR-101.
+Tavily Search Service — ADR-101, ADR-131.
 
 Phase 2 채용 트렌드 검색: 검색 쿼리 기반 자동 URL 발견 + 본문 추출.
 
@@ -8,6 +8,11 @@ Phase 1 (WebBaseLoader) 대비 장점:
 - JS 렌더링 지원 (채용 사이트 SPA 대응)
 - 메타데이터(제목, URL, score) 자동 제공 → LLM 메타데이터 추출 비용 절감
 - 중복 URL 자동 필터링
+
+ADR-131 추가 신뢰성 검증:
+- days 파라미터로 API 레벨 날짜 필터 (최신 데이터만 수신)
+- score 임계값 미달 결과 제거 (저품질 문서 차단)
+- 최소 본문 길이 미달 결과 제거 (스텁 페이지 차단)
 """
 
 from __future__ import annotations
@@ -42,6 +47,8 @@ class TavilySearchStats:
     total_queries: int
     total_results: int
     deduplicated_results: int
+    filtered_by_score: int = 0         # ADR-131: score 임계값 미달로 제거된 수
+    filtered_by_length: int = 0        # ADR-131: 최소 본문 길이 미달로 제거된 수
     failed_queries: list[str] = field(default_factory=list)
 
 
@@ -65,62 +72,132 @@ class TavilySearchService:
                 "Tavily 홈페이지(https://tavily.com)에서 API 키를 발급받아 설정하세요."
             )
 
-    async def search(
+    async def _search(
         self,
         query: str,
         max_results: int | None = None,
-    ) -> list[TavilySearchResult]:
-        """단일 쿼리로 관련 웹 페이지 검색 + 본문 추출.
-
-        Args:
-            query: 검색 쿼리 (예: "2026 백엔드 채용 트렌드")
-            max_results: 최대 결과 수 (기본값: settings.tavily_max_results)
+    ) -> tuple[list[TavilySearchResult], int, int]:
+        """단일 쿼리 검색 내부 구현 — 필터 통계 포함 반환 (ADR-101, ADR-131).
 
         Returns:
-            TavilySearchResult 리스트 (content 없는 결과 제외)
+            (results, filtered_by_score, filtered_by_length)
+
+        Filters (ADR-131):
+            1. API 레벨: days 파라미터 → 오래된 문서 수신 차단
+            2. 빈 콘텐츠 제거
+            3. 최소 본문 길이(tavily_min_content_length) 미달 제거
+            4. 최소 score(tavily_min_score) 미달 제거
         """
         from langchain_tavily import TavilySearch
 
         n = max_results or self.settings.tavily_max_results
 
         try:
-            tool = TavilySearch(
-                api_key=self.settings.tavily_api_key,
-                max_results=n,
-                search_depth=self.settings.tavily_search_depth,
-                include_raw_content=True,
-            )
+            # ADR-131: API 레벨 날짜 필터 — 오래된 문서를 수신 전 차단 (가장 효율적)
+            tool_kwargs: dict = {
+                "api_key": self.settings.tavily_api_key,
+                "max_results": n,
+                "search_depth": self.settings.tavily_search_depth,
+                "include_raw_content": True,
+            }
+            if self.settings.tavily_days > 0:
+                tool_kwargs["days"] = self.settings.tavily_days
+
+            tool = TavilySearch(**tool_kwargs)
 
             # SAST: 쿼리는 사용자 입력이므로 로그에 직접 포함하지 않음
             logger.info(
-                "[Tavily] 검색 실행 (depth=%s, max=%d)", self.settings.tavily_search_depth, n
+                "[Tavily] 검색 실행 (depth=%s, max=%d, days=%s, min_score=%.2f)",
+                self.settings.tavily_search_depth,
+                n,
+                self.settings.tavily_days or "무제한",
+                self.settings.tavily_min_score,
             )
 
             raw = await tool.ainvoke({"query": query})
             items = raw if isinstance(raw, list) else raw.get("results", [])
 
             results = []
+            filtered_score = 0
+            filtered_length = 0
+
             for r in items:
                 content = r.get("raw_content") or r.get("content", "")
+                score = float(r.get("score", 0.0))
+
+                # 필터 1: 빈 콘텐츠
                 if not content:
+                    logger.debug("[Tavily] 빈 콘텐츠 제거: %s", r.get("url", ""))
                     continue
+
+                # 필터 2: 최소 본문 길이 (ADR-131)
+                if (
+                    self.settings.tavily_min_content_length > 0
+                    and len(content) < self.settings.tavily_min_content_length
+                ):
+                    logger.debug(
+                        "[Tavily] 짧은 콘텐츠 제거 (%d자 < %d자): %s",
+                        len(content),
+                        self.settings.tavily_min_content_length,
+                        r.get("url", ""),
+                    )
+                    filtered_length += 1
+                    continue
+
+                # 필터 3: 최소 relevance score (ADR-131)
+                if (
+                    self.settings.tavily_min_score > 0.0
+                    and score < self.settings.tavily_min_score
+                ):
+                    logger.debug(
+                        "[Tavily] 낮은 score 제거 (%.2f < %.2f): %s",
+                        score,
+                        self.settings.tavily_min_score,
+                        r.get("url", ""),
+                    )
+                    filtered_score += 1
+                    continue
+
                 results.append(
                     TavilySearchResult(
                         title=r.get("title", ""),
                         url=r.get("url", ""),
                         content=content,
-                        score=float(r.get("score", 0.0)),
+                        score=score,
                         published_date=r.get("published_date"),
                         query=query,
                     )
                 )
 
-            logger.info("[Tavily] 검색 완료: %d건 반환", len(results))
-            return results
+            logger.info(
+                "[Tavily] 검색 완료: %d건 반환 (원본 %d건, score 필터 %d건, 길이 필터 %d건)",
+                len(results),
+                len(items),
+                filtered_score,
+                filtered_length,
+            )
+            return results, filtered_score, filtered_length
 
         except Exception as e:
             logger.error("[Tavily] 검색 실패: %s", e)
             raise
+
+    async def search(
+        self,
+        query: str,
+        max_results: int | None = None,
+    ) -> list[TavilySearchResult]:
+        """단일 쿼리로 관련 웹 페이지 검색 + 본문 추출 (ADR-101, ADR-131).
+
+        Args:
+            query: 검색 쿼리 (예: "2026 백엔드 채용 트렌드")
+            max_results: 최대 결과 수 (기본값: settings.tavily_max_results)
+
+        Returns:
+            TavilySearchResult 리스트 (신뢰성 필터 통과한 결과만)
+        """
+        results, _, _ = await self._search(query, max_results)
+        return results
 
     async def search_multiple(
         self,
@@ -132,25 +209,30 @@ class TavilySearchService:
             queries: 검색 쿼리 목록
 
         Returns:
-            (중복 제거된 결과 리스트, 검색 통계)
+            (중복 제거된 결과 리스트, 검색 통계 — filtered_by_score/length 포함)
         """
         logger.info("[Tavily] 병렬 검색 시작: %d개 쿼리", len(queries))
 
-        tasks = [self.search(q) for q in queries]
+        tasks = [self._search(q) for q in queries]
         results_list = await asyncio.gather(*tasks, return_exceptions=True)
 
         seen_urls: set[str] = set()
         merged: list[TavilySearchResult] = []
         failed_queries: list[str] = []
         total_raw = 0
+        total_filtered_score = 0
+        total_filtered_length = 0
 
-        for query, results in zip(queries, results_list, strict=False):
-            if isinstance(results, Exception):
-                logger.warning("[Tavily] 쿼리 실패 (계속 진행): %s", results)
+        for query, result in zip(queries, results_list, strict=False):
+            if isinstance(result, Exception):
+                logger.warning("[Tavily] 쿼리 실패 (계속 진행): %s", result)
                 failed_queries.append(query)
                 continue
 
+            results, filtered_score, filtered_length = result
             total_raw += len(results)
+            total_filtered_score += filtered_score
+            total_filtered_length += filtered_length
             for r in results:
                 if r.url not in seen_urls:
                     seen_urls.add(r.url)
@@ -160,13 +242,19 @@ class TavilySearchService:
             total_queries=len(queries),
             total_results=total_raw,
             deduplicated_results=len(merged),
+            filtered_by_score=total_filtered_score,
+            filtered_by_length=total_filtered_length,
             failed_queries=failed_queries,
         )
 
         logger.info(
-            "[Tavily] 병렬 검색 완료: 총 %d건 → 중복 제거 후 %d건 (실패 쿼리 %d개)",
+            "[Tavily] 병렬 검색 완료: 총 %d건 → 중복 제거 후 %d건"
+            " (실패 %d개, score 필터 %d건, 길이 필터 %d건, days=%s)",
             total_raw,
             len(merged),
             len(failed_queries),
+            total_filtered_score,
+            total_filtered_length,
+            self.settings.tavily_days or "무제한",
         )
         return merged, stats


### PR DESCRIPTION
## 작업한 내용

### ADR-131: Tavily 결과 신뢰성 검증 + 최신 데이터 필터링

#### 배경
Tavily API 검색 결과에 오래된 문서(2019~2022년)와 저품질 문서(score < 0.5)가 혼입되어 ChromaDB `trend_data`에 적재되면 RAG 답변 품질이 저하되는 문제

#### 변경 사항

**`app/config/settings.py`**
- `tavily_days=90` — Tavily API `days` 파라미터, 최근 N일 이내 문서만 수신 (`0` = 제한 없음)
- `tavily_min_score=0.5` — 최소 relevance score 임계값 (`0.0` = 비활성화)
- `tavily_min_content_length=200` — 최소 본문 길이, 스텁 페이지 제거 (`0` = 비활성화)
- Pydantic `ge`/`le` 범위 제약 추가 → 잘못된 환경변수 값을 앱 시작 시점에 즉시 감지

**`app/services/tavily_search_service.py`**
- 3단계 필터 파이프라인 구현
  1. API 레벨: `days` 파라미터로 오래된 문서 수신 전 차단 (가장 효율적)
  2. 최소 본문 길이 필터: 스텁 페이지(짧은 텍스트) 제거
  3. 최소 score 필터: 저관련성 문서 제거
- `_search()` 내부 메서드 분리 → `(results, filtered_score, filtered_length)` 반환
- `search()` 공개 API 시그니처 그대로 유지 (하위 호환)
- `search_multiple()`에서 `_search()` 호출로 전환 → 전체 쿼리 필터 통계를 `TavilySearchStats.filtered_by_score/length`에 실집계

#### 하위 호환
`TAVILY_DAYS=0`, `TAVILY_MIN_SCORE=0.0`, `TAVILY_MIN_CONTENT_LENGTH=0` 설정 시 모든 필터 비활성화 → ADR-101 이전 동작과 동일

---

## Test plan

- [ ] `POST /crawl/trend/search` 호출 후 반환 `success_count`가 이전보다 줄어드는지 확인 (필터 작동)
- [ ] 로그에서 `[Tavily] score 필터 N건, 길이 필터 N건` 수치 확인
- [ ] `TAVILY_MIN_SCORE=0.0`, `TAVILY_DAYS=0` 설정 시 기존과 동일한 결과 수 반환 확인 (하위호환)
- [ ] `TAVILY_MIN_SCORE=1.5` 등 범위 초과 값 설정 시 앱 기동 실패로 즉시 감지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)