### PR TITLE
feat: BM25+MMR 앙상블 검증 로그 추가

### DIFF
--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -912,6 +912,8 @@ class RAGService:
                 else:
                     dense_pairs = all_dense_pairs
 
+                logger.info("[Ensemble] Dense(MMR): %d건", len(dense_pairs))
+
                 results_per_type = await asyncio.gather(
                     *[
                         self.vectordb.get_all_documents_by_user(user_id=user_id, collection_type=ct)
@@ -929,6 +931,8 @@ class RAGService:
                 if settings.rag_bm25_max_docs > 0 and len(bm25_docs) > settings.rag_bm25_max_docs:
                     bm25_docs = bm25_docs[: settings.rag_bm25_max_docs]
 
+                logger.info("[Ensemble] BM25 인덱스: %d건", len(bm25_docs))
+
                 sparse_pairs: list[tuple[str, Document]] = []
                 if bm25_docs and query.strip():
                     k_bm25 = max(10, min(50, len(bm25_docs)))
@@ -941,6 +945,8 @@ class RAGService:
                     sparse_docs = await loop.run_in_executor(None, _bm25_invoke)
                     sparse_pairs = [(d.metadata.get("collection_type", ""), d) for d in sparse_docs]
 
+                logger.info("[Ensemble] Sparse(BM25): %d건", len(sparse_pairs))
+
                 dw = (
                     dense_weight if dense_weight is not None else settings.rag_ensemble_dense_weight
                 )
@@ -950,6 +956,12 @@ class RAGService:
                     else settings.rag_ensemble_sparse_weight
                 )
                 merged = _rrf_merge(dense_pairs, sparse_pairs, dw, sw, top_k=0)
+                logger.info(
+                    "[Ensemble] RRF 병합: %d건 (dense=%.1f, sparse=%.1f)",
+                    len(merged),
+                    dw,
+                    sw,
+                )
 
                 # ADR-106 Phase 4: RAPTOR 다단계 검색 결과 병합
                 if self._raptor:


### PR DESCRIPTION
## 작업한 내용

### BM25 + MMR 앙상블 파이프라인 검증 로그

#### 배경
`rag_service.py`의 Dense(MMR) + Sparse(BM25) 앙상블 경로에 `logger.info`가 전혀 없어, 서버 로그만으로 BM25가 실제로 실행됐는지 확인 불가

#### 변경 사항

**`app/services/rag_service.py`**
- 앙상블 블록 4단계에 검증 로그 추가:
  1. `[Ensemble] Dense(MMR): N건` — MMR 검색 결과 수
  2. `[Ensemble] BM25 인덱스: N건` — BM25가 색인할 전체 문서 수 (상한 적용 후)
  3. `[Ensemble] Sparse(BM25): N건` — BM25 검색 결과 수
  4. `[Ensemble] RRF 병합: N건 (dense=0.7, sparse=0.3)` — RRF 병합 최종 수
- `Sparse(BM25)` 로그를 `if bm25_docs and query.strip():` 블록 **밖**으로 이동
  - BM25가 스킵될 경우에도 `0건`으로 항상 출력 → 스킵 여부 명시적 확인 가능

#### 검증 방법

채팅 API 호출 시 서버 로그에 아래 4줄이 연속 출력되면 앙상블 정상 작동:

```
[Ensemble] Dense(MMR): 5건
[Ensemble] BM25 인덱스: 42건
[Ensemble] Sparse(BM25): 10건
[Ensemble] RRF 병합: 14건 (dense=0.7, sparse=0.3)
```

| 이상 신호 | 의미 |
|----------|------|
| `Sparse(BM25): 0건` | BM25 인덱스 비어있거나 query 빈 문자열 |
| `RRF 병합: 0건` | Dense + Sparse 모두 결과 없음 |
| `RAG ensemble failed, fallback to dense-only` | 앙상블 예외 발생 → dense-only 폴백 |

---

## Test plan

- [ ] 채팅 API 호출 후 서버 로그에서 `[Ensemble]` 4줄 출력 확인
- [ ] 문서가 없는 사용자로 호출 시 `Sparse(BM25): 0건` 출력 확인 (스킵 케이스 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)