### PR TITLE
feat: ADR-132/133 Redis 마이그레이션 및 SageMaker 설정 중앙화

### DIFF
--- a/app/config/dependencies.py
+++ b/app/config/dependencies.py
@@ -132,14 +132,15 @@ def get_session_store(
 ) -> "BaseSessionStore":
     """Get session store instance.
 
-    Returns Redis in production, in-memory otherwise.
-    In-memory store is a singleton so interview sessions are shared across requests.
+    redis_url 설정 시 RedisSessionStore 반환, 미설정 시 InMemorySessionStore 폴백.
+    k8s 멀티 파드 환경에서 파드 간 세션 공유를 보장하기 위해 is_production 대신
+    redis_url 체크로 변경 (ADR-130 패턴 적용).
     """
     global _session_store_instance
     if _session_store_instance is not None:
         return _session_store_instance
 
-    if settings.is_production:
+    if settings.redis_url:
         from app.infrastructure.session.redis import RedisSessionStore
 
         _session_store_instance = RedisSessionStore(
@@ -163,9 +164,11 @@ def get_task_queue(
 ) -> "BaseTaskQueue":
     """Get task queue instance.
 
-    Returns Celery in production, file-based otherwise.
+    redis_url 설정 시 CeleryTaskQueue 반환, 미설정 시 FileTaskQueue 폴백.
+    k8s 멀티 파드 환경에서 파드 간 태스크 유실을 방지하기 위해 is_production 대신
+    redis_url 체크로 변경 (ADR-130 패턴 적용).
     """
-    if settings.is_production:
+    if settings.redis_url:
         from app.infrastructure.queue.celery_queue import CeleryTaskQueue
 
         return CeleryTaskQueue(
@@ -182,7 +185,7 @@ def get_task_queue(
 # Legacy Task Storage (save/get dict - ai.py 호환)
 # ============================================
 
-_task_storage_instance = None        # FileTaskStore fallback 싱글톤
+_task_storage_instance = None  # FileTaskStore fallback 싱글톤
 _redis_task_storage_instance = None  # RedisTaskStore 싱글톤 (ADR-130)
 
 
@@ -221,7 +224,7 @@ def get_legacy_task_storage(
 
         _redis_task_storage_instance = RedisTaskStore(
             redis_url=actual_settings.redis_url,  # DB 0, prefix "legacy_task:"으로 세션과 네임스페이스 분리
-            ttl=actual_settings.redis_task_ttl,   # 기본 86400초 (24시간)
+            ttl=actual_settings.redis_task_ttl,  # 기본 86400초 (24시간)
         )
         return _redis_task_storage_instance
 

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -378,6 +378,26 @@ class Settings(BaseSettings):
     )
 
     # ============================================
+    # AWS / SageMaker Configuration (ADR-117, ADR-133)
+    # ============================================
+    aws_region: str = Field(
+        default="ap-northeast-2",
+        description="AWS 리전 (S3, SageMaker 공통)",
+    )
+    sagemaker_s3_bucket: str = Field(
+        default="devths-storage-dev",
+        description="SageMaker 학습 데이터 S3 버킷",
+    )
+    sagemaker_s3_training_prefix: str = Field(
+        default="uploads/training-data/",
+        description="학습 데이터 S3 경로 프리픽스",
+    )
+    sagemaker_pipeline_name: str = Field(
+        default="exaone-finetuning-pipeline",
+        description="SageMaker Pipeline 이름 (파인튜닝 파이프라인)",
+    )
+
+    # ============================================
     # Task Queue Configuration
     # ============================================
     task_storage_dir: str = Field(

--- a/app/tasks/sagemaker_sync_tasks.py
+++ b/app/tasks/sagemaker_sync_tasks.py
@@ -11,24 +11,21 @@ Redis를 통한 분산 태스크 처리.
   Prod VectorDB(ChromaDB) → 익명화 → S3 스테이징 버킷 → SageMaker Pipeline 트리거
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
-import os
 import re
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.config.settings import Settings
 
 from app.tasks.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
-
-# S3 설정
-S3_BUCKET = os.getenv("SAGEMAKER_S3_BUCKET", "devths-storage-dev")
-S3_TRAINING_DATA_PREFIX = os.getenv("SAGEMAKER_S3_TRAINING_PREFIX", "uploads/training-data/")
-
-# SageMaker Pipeline 설정
-SAGEMAKER_PIPELINE_NAME = os.getenv("SAGEMAKER_PIPELINE_NAME", "exaone-finetuning-pipeline")
-AWS_REGION = os.getenv("AWS_REGION", "ap-northeast-2")
 
 # 학습에 사용할 VectorDB 컬렉션 목록
 TRAINING_COLLECTIONS = [
@@ -102,24 +99,26 @@ def _extract_collection_data(vectordb, collection_type: str) -> list[dict]:
     return records
 
 
-def _upload_to_s3(records: list[dict], collection_type: str, timestamp: str) -> str:
+def _upload_to_s3(
+    records: list[dict], collection_type: str, timestamp: str, settings: Settings
+) -> str:
     """학습 데이터를 JSONL 형식으로 S3에 업로드."""
     import boto3
 
-    s3_client = boto3.client("s3", region_name=AWS_REGION)
+    s3_client = boto3.client("s3", region_name=settings.aws_region)
 
-    s3_key = f"{S3_TRAINING_DATA_PREFIX}{timestamp}/{collection_type}.jsonl"
+    s3_key = f"{settings.sagemaker_s3_training_prefix}{timestamp}/{collection_type}.jsonl"
 
     jsonl_content = "\n".join(json.dumps(record, ensure_ascii=False) for record in records)
 
     s3_client.put_object(
-        Bucket=S3_BUCKET,
+        Bucket=settings.sagemaker_s3_bucket,
         Key=s3_key,
         Body=jsonl_content.encode("utf-8"),
         ContentType="application/jsonl",
     )
 
-    s3_uri = f"s3://{S3_BUCKET}/{s3_key}"
+    s3_uri = f"s3://{settings.sagemaker_s3_bucket}/{s3_key}"
     logger.info("[SageMakerSync] S3 업로드 완료: %s (%d건)", s3_uri, len(records))
     return s3_uri
 
@@ -179,7 +178,7 @@ async def _sync_training_data_async() -> dict:
             continue
 
         # S3 업로드
-        s3_uri = _upload_to_s3(records, collection_type, timestamp)
+        s3_uri = _upload_to_s3(records, collection_type, timestamp, settings)
         total_records += len(records)
         uploaded_files.append(
             {
@@ -193,7 +192,7 @@ async def _sync_training_data_async() -> dict:
         "status": "completed",
         "timestamp": timestamp,
         "total_records": total_records,
-        "s3_base_path": f"s3://{S3_BUCKET}/{S3_TRAINING_DATA_PREFIX}{timestamp}/",
+        "s3_base_path": f"s3://{settings.sagemaker_s3_bucket}/{settings.sagemaker_s3_training_prefix}{timestamp}/",
         "uploaded_files": uploaded_files,
     }
 
@@ -210,19 +209,25 @@ def trigger_sagemaker_pipeline_task(self, s3_data_path: str = ""):
     Args:
         s3_data_path: S3 학습 데이터 경로 (미지정 시 latest 사용)
     """
-    logger.info("[SageMakerSync] SageMaker Pipeline 트리거: %s", SAGEMAKER_PIPELINE_NAME)
-
     try:
+        from app.config.settings import get_settings
+
+        settings = get_settings()
+
+        logger.info(
+            "[SageMakerSync] SageMaker Pipeline 트리거: %s", settings.sagemaker_pipeline_name
+        )
+
         import boto3
 
-        sm_client = boto3.client("sagemaker", region_name=AWS_REGION)
+        sm_client = boto3.client("sagemaker", region_name=settings.aws_region)
 
         params = []
         if s3_data_path:
             params.append({"Name": "ChromaDataS3Uri", "Value": s3_data_path})
 
         response = sm_client.start_pipeline_execution(
-            PipelineName=SAGEMAKER_PIPELINE_NAME,
+            PipelineName=settings.sagemaker_pipeline_name,
             PipelineParameters=params,
             PipelineExecutionDescription=f"Auto-triggered by Celery Beat at {datetime.now().isoformat()}",
         )
@@ -232,7 +237,7 @@ def trigger_sagemaker_pipeline_task(self, s3_data_path: str = ""):
 
         return {
             "status": "pipeline_triggered",
-            "pipeline_name": SAGEMAKER_PIPELINE_NAME,
+            "pipeline_name": settings.sagemaker_pipeline_name,
             "execution_arn": execution_arn,
             "s3_data_path": s3_data_path,
         }

--- a/docker-compose.cicd.yml
+++ b/docker-compose.cicd.yml
@@ -103,13 +103,14 @@ services:
       - ai_network
 
   # -----------------------------------------
-  # 2. Celery Worker — 트렌드 크롤링 전용 (ADR-094)
+  # 2. Celery Worker — 트렌드 크롤링 + SageMaker 동기화 (ADR-094, ADR-133)
   # -----------------------------------------
   celery-worker-trend:
     image: ${IMAGE_URI}
     container_name: celery_worker_trend
     restart: unless-stopped
-    command: poetry run celery -A app.tasks.celery_app worker --loglevel=info -Q trend_crawl
+    # ADR-133: sagemaker_sync 큐 합산 (ChromaDB 공유, 주 1회 단발)
+    command: poetry run celery -A app.tasks.celery_app worker --loglevel=info -Q trend_crawl,sagemaker_sync
     environment:
       - ENVIRONMENT=production
       - REDIS_URL=${REDIS_URL}
@@ -133,6 +134,13 @@ services:
       - RAG_MULTI_QUERY_COUNT=${RAG_MULTI_QUERY_COUNT:-}
       - RAG_USE_TIME_WEIGHTED=${RAG_USE_TIME_WEIGHTED:-}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      # SageMaker (ADR-117, ADR-133) — S3 업로드 및 Pipeline 트리거
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_REGION=${AWS_REGION:-ap-northeast-2}
+      - SAGEMAKER_S3_BUCKET=${SAGEMAKER_S3_BUCKET:-devths-storage-dev}
+      - SAGEMAKER_S3_TRAINING_PREFIX=${SAGEMAKER_S3_TRAINING_PREFIX:-uploads/training-data/}
+      - SAGEMAKER_PIPELINE_NAME=${SAGEMAKER_PIPELINE_NAME:-exaone-finetuning-pipeline}
     logging:
       driver: json-file
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,9 @@ services:
       - ai_network
 
   # -----------------------------------------
-  # 2. Celery Worker (트렌드 크롤링 태스크 처리) — ADR-094/096
+  # 2. Celery Worker (트렌드 크롤링 + SageMaker 동기화) — ADR-094/096, ADR-133
   # Redis/ElastiCache 연결은 환경변수로 주입
+  # ADR-133: sagemaker_sync 큐를 trend_crawl과 합산 (ChromaDB 공유, 주 1회 단발 실행)
   # -----------------------------------------
   celery-worker-trend:
     build:
@@ -63,7 +64,7 @@ services:
       dockerfile: Dockerfile
     image: ai-endpoint:v2
     container_name: celery_worker_trend
-    command: celery -A app.tasks.celery_app worker --loglevel=info -Q trend_crawl
+    command: celery -A app.tasks.celery_app worker --loglevel=info -Q trend_crawl,sagemaker_sync
     environment:
       - ENVIRONMENT=production
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
@@ -74,6 +75,13 @@ services:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
       - TREND_CRAWL_URLS=${TREND_CRAWL_URLS:-}
       - TAVILY_API_KEY=${TAVILY_API_KEY:-}
+      # SageMaker 학습 데이터 동기화 (ADR-133)
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_REGION=${AWS_REGION:-ap-northeast-2}
+      - SAGEMAKER_S3_BUCKET=${SAGEMAKER_S3_BUCKET:-devths-storage-dev}
+      - SAGEMAKER_S3_TRAINING_PREFIX=${SAGEMAKER_S3_TRAINING_PREFIX:-uploads/training-data/}
+      - SAGEMAKER_PIPELINE_NAME=${SAGEMAKER_PIPELINE_NAME:-exaone-finetuning-pipeline}
     depends_on:
       vectordb:
         condition: service_started


### PR DESCRIPTION
## Summary

- **ADR-132** — k8s replica=2 파드 간 상태 공유 문제 해결
  - `get_session_store()`: `is_production` → `redis_url` 체크로 변경 (InMemoryStore → RedisSessionStore 자동 전환)
  - `get_task_queue()`: `is_production` → `redis_url` 체크로 변경 (FileTaskQueue → CeleryTaskQueue 자동 전환)
  - PV/PVC 없는 k8s 환경에서 파드 간 세션 강제 종료 및 태스크 유실 방지

- **ADR-133** — SageMaker `sagemaker_sync` 큐 워커 미등록 문제 해결
  - `celery-worker-trend`에 `sagemaker_sync` 큐 합산 (ChromaDB 공유, 주 1회 단발 실행)
  - `settings.py`에 AWS/SageMaker Pydantic Field 4개 추가 (`aws_region`, `sagemaker_s3_bucket`, `sagemaker_s3_training_prefix`, `sagemaker_pipeline_name`)
  - `sagemaker_sync_tasks.py` 모듈 레벨 `os.getenv()` 제거 → `get_settings()` 객체 사용으로 설정 중앙화
  - `docker-compose.yml` / `docker-compose.cicd.yml` 양쪽 동기화

## Changed Files

| 파일 | 변경 내용 |
|------|---------|
| `app/config/dependencies.py` | `get_session_store` / `get_task_queue` `redis_url` 체크 |
| `app/config/settings.py` | AWS/SageMaker Pydantic Field 4개 추가 |
| `app/tasks/sagemaker_sync_tasks.py` | `os.getenv()` → `settings` 객체, 타입 힌트, retry 보호 |
| `docker-compose.yml` | `sagemaker_sync` 큐 + AWS 환경변수 |
| `docker-compose.cicd.yml` | 동일 변경 CI/CD 환경 동기화 |

## Test plan

- [ ] `REDIS_URL` 설정 시 `get_session_store()` → `RedisSessionStore` 반환 확인
- [ ] `REDIS_URL` 미설정(`=""`) 시 `get_session_store()` → `InMemorySessionStore` 폴백 확인
- [ ] `celery -A app.tasks.celery_app worker -Q trend_crawl,sagemaker_sync` 워커 기동 확인
- [ ] `from app.config.settings import get_settings; s = get_settings(); print(s.aws_region)` 정상 출력 확인