### PR TITLE
Feat/ai backend enhancement

### DIFF
--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -34,6 +34,7 @@ from app.prompts import (
     create_followup_prompt,
 )
 from app.prompts.interview import create_feedback_prompt
+from app.utils.langfuse_client import create_retrieval_span, trace_llm_call
 from app.utils.log_sanitizer import sanitize_log_input
 
 from .example_selector import get_few_shot_for_general
@@ -862,6 +863,18 @@ class RAGService:
                 if not types_to_fetch:
                     return ""
 
+                # ADR-134: 앙상블 파이프라인 단계별 Langfuse span 추적
+                _lf_trace = trace_llm_call(
+                    name="rag-ensemble-retrieval",
+                    user_id=user_id,
+                    metadata={
+                        "context_types": context_types,
+                        "rag_use_bm25": True,
+                        "rag_use_parent_retriever": settings.rag_use_parent_retriever,
+                        "multi_query": len(queries) > 1,
+                    },
+                )
+
                 # ADR-077: 각 쿼리별 dense 검색 후 병합
                 # ADR-076: resumes/portfolios는 ParentDocumentRetriever 경로로 분기
                 all_dense_pairs: list[tuple[str, Document]] = []
@@ -913,6 +926,12 @@ class RAGService:
                     dense_pairs = all_dense_pairs
 
                 logger.info("[Ensemble] Dense(MMR): %d건", len(dense_pairs))
+                create_retrieval_span(
+                    _lf_trace,
+                    "dense-mmr",
+                    input_data={"queries_count": len(queries), "context_types": types_to_fetch},
+                    output_data={"count": len(dense_pairs)},
+                )
 
                 results_per_type = await asyncio.gather(
                     *[
@@ -932,6 +951,14 @@ class RAGService:
                     bm25_docs = bm25_docs[: settings.rag_bm25_max_docs]
 
                 logger.info("[Ensemble] BM25 인덱스: %d건", len(bm25_docs))
+                create_retrieval_span(
+                    _lf_trace,
+                    "bm25-index",
+                    output_data={
+                        "bm25_doc_count": len(bm25_docs),
+                        "bm25_max_docs_limit": settings.rag_bm25_max_docs,
+                    },
+                )
 
                 sparse_pairs: list[tuple[str, Document]] = []
                 if bm25_docs and query.strip():
@@ -946,6 +973,15 @@ class RAGService:
                     sparse_pairs = [(d.metadata.get("collection_type", ""), d) for d in sparse_docs]
 
                 logger.info("[Ensemble] Sparse(BM25): %d건", len(sparse_pairs))
+                create_retrieval_span(
+                    _lf_trace,
+                    "sparse-bm25",
+                    input_data={
+                        "query_stripped": bool(query.strip()),
+                        "bm25_skipped": not bm25_docs,
+                    },
+                    output_data={"count": len(sparse_pairs)},
+                )
 
                 dw = (
                     dense_weight if dense_weight is not None else settings.rag_ensemble_dense_weight
@@ -961,6 +997,16 @@ class RAGService:
                     len(merged),
                     dw,
                     sw,
+                )
+                create_retrieval_span(
+                    _lf_trace,
+                    "rrf-merge",
+                    input_data={"dense_weight": dw, "sparse_weight": sw},
+                    output_data={
+                        "merged_count": len(merged),
+                        "dense_input": len(dense_pairs),
+                        "sparse_input": len(sparse_pairs),
+                    },
                 )
 
                 # ADR-106 Phase 4: RAPTOR 다단계 검색 결과 병합
@@ -983,7 +1029,17 @@ class RAGService:
 
                 # 재정렬: top_k 적용 (ADR-069 question → retriever → rerank → context)
                 rerank_k = settings.rag_rerank_top_k if settings.rag_rerank_top_k > 0 else 0
+                count_before_rerank = len(merged)
                 merged = await _rerank(merged, rerank_k, query=query)
+                create_retrieval_span(
+                    _lf_trace,
+                    "rerank-flashrank",
+                    input_data={"rerank_k": rerank_k, "use_flashrank": settings.rag_use_flashrank},
+                    output_data={
+                        "count_before": count_before_rerank,
+                        "count_after": len(merged),
+                    },
+                )
 
                 if settings.rag_use_compressor and merged:
                     llm = getattr(getattr(self._rag_chain, "_llm_gateway", None), "llm", None)

--- a/app/utils/langfuse_client.py
+++ b/app/utils/langfuse_client.py
@@ -189,6 +189,60 @@ def create_generation(
         return None
 
 
+def create_retrieval_span(
+    trace: "LangfuseTraceContext | None",
+    name: str,
+    input_data: dict | None = None,
+    output_data: dict | None = None,
+    metadata: dict | None = None,
+) -> None:
+    """ADR-134: RAG 검색 단계를 Langfuse span으로 기록.
+
+    LLM이 아닌 검색 파이프라인 단계(Dense-MMR, BM25 인덱스, Sparse-BM25, RRF 병합, Rerank)를 추적.
+    Langfuse Observations 탭에서 단계별 문서 수·가중치를 확인할 수 있다.
+    Langfuse 미설정 또는 오류 시 no-op으로 동작 (서비스 중단 없음).
+
+    Args:
+        trace: trace_llm_call()로 생성한 컨텍스트
+        name: span 이름 ("dense-mmr", "bm25-index", "sparse-bm25", "rrf-merge", "rerank")
+        input_data: 검색 파라미터 (query, weights 등)
+        output_data: 결과 통계 (count, merged_count 등)
+        metadata: 추가 메타데이터
+    """
+    if trace is None:
+        return
+    try:
+        client = trace["client"]
+        trace_id = trace["trace_id"]
+
+        observation = None
+        # Langfuse v3: start_observation(as_type="span")
+        if hasattr(client, "start_observation"):
+            with contextlib.suppress(Exception):
+                observation = client.start_observation(
+                    name=name,
+                    as_type="span",
+                    trace_context={"trace_id": trace_id},
+                    input=input_data,
+                    output=output_data,
+                    metadata=metadata or {},
+                )
+        # Langfuse v2 fallback: start_span
+        if observation is None and hasattr(client, "start_span"):
+            with contextlib.suppress(Exception):
+                observation = client.start_span(
+                    name=name,
+                    trace_context={"trace_id": trace_id},
+                    input=input_data,
+                    output=output_data,
+                    metadata=metadata or {},
+                )
+        if observation and hasattr(observation, "end"):
+            observation.end()
+    except Exception as e:
+        logger.error("Langfuse span 기록 실패 (name=%s): %s", name, e)
+
+
 def record_score(
     trace: "LangfuseTraceContext | None",
     name: str,


### PR DESCRIPTION
## 📌 작업한 내용

Langfuse 트래킹 로그 추가


Langfuse Traces 탭 → "rag-ensemble-retrieval" 클릭
  └─ Observations 탭
       ├─ dense-mmr          output: {count: 28}
       ├─ bm25-index         output: {bm25_doc_count: 95, bm25_max_docs_limit: 500}
       ├─ sparse-bm25        output: {count: 15}  input: {bm25_skipped: false}
       ├─ rrf-merge          output: {merged_count: 35, dense_input: 28, sparse_input: 15}
       │                     input: {dense_weight: 0.7, sparse_weight: 0.3}
       └─ rerank-flashrank   output: {count_before: 35, count_after: 5}

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
