### PR TITLE
fix: chromadb 0.5.x Content-Type 헤더 누락 버그 우회 (Issue #3899)

### DIFF
--- a/app/infrastructure/vectordb/chroma.py
+++ b/app/infrastructure/vectordb/chroma.py
@@ -65,6 +65,12 @@ class ChromaVectorStore(BaseVectorStore):
             self.chroma_client = chromadb.HttpClient(
                 host=chroma_server_host,
                 port=chroma_server_port,
+                settings=Settings(
+                    anonymized_telemetry=False,
+                    # chromadb 0.5.x 클라이언트 버그: orjson bytes 전송 시 Content-Type 미설정
+                    # httpx content=bytes 방식에서 헤더를 명시적으로 주입 (Issue #3899)
+                    chroma_server_headers={"Content-Type": "application/json"},
+                ),
             )
             logger.info(
                 f"ChromaVectorStore initialized (server mode) at {chroma_server_host}:{chroma_server_port}"

--- a/app/services/vectordb_service.py
+++ b/app/services/vectordb_service.py
@@ -83,6 +83,12 @@ class VectorDBService:
             self.chroma_client = chromadb.HttpClient(
                 host=chroma_server_host,
                 port=chroma_server_port,
+                settings=Settings(
+                    anonymized_telemetry=False,
+                    # chromadb 0.5.x 클라이언트 버그: orjson bytes 전송 시 Content-Type 미설정
+                    # httpx content=bytes 방식에서 헤더를 명시적으로 주입 (Issue #3899)
+                    chroma_server_headers={"Content-Type": "application/json"},
+                ),
             )
             logger.info(
                 f"VectorDB Service initialized (server mode) at {chroma_server_host}:{chroma_server_port}"


### PR DESCRIPTION


## 📌 작업한 내용
chromadb 0.5.x 클라이언트가 orjson.dumps() + content=bytes 방식으로 요청 시 httpx가 Content-Type 헤더를 자동 설정하지 않아 서버에서 model_attributes_type 에러 발생.

HttpClient Settings에 chroma_server_headers 명시로 헤더 강제 주입:
- app/infrastructure/vectordb/chroma.py
- app/services/vectordb_service.py
## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
