### PR TITLE
fix: OpenTelemetry TracerProvider API 수정

### DIFF
--- a/app/core/telemetry.py
+++ b/app/core/telemetry.py
@@ -64,7 +64,7 @@ def setup_tracing() -> None:
         exporter = OTLPSpanExporter(endpoint=endpoint)
         provider.add_span_processor(BatchSpanProcessor(exporter))
 
-        trace.set_global_tracer_provider(provider)
+        trace.set_tracer_provider(provider)
 
         # httpx 자동 계측 (외부 API 호출 — BE, Gemini, OpenAI 등)
         HTTPXClientInstrumentor().instrument()


### PR DESCRIPTION
set_global_tracer_provider → set_tracer_provider
opentelemetry-api 1.x에서 set_global_tracer_provider 제거로 Celery 앱 로드 실패 수정

## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
