### PR TITLE
fix: Celery 워커에 ChromaDB 버그 패치 적용 (#chromadb)

### DIFF
--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -23,10 +23,16 @@ from celery.schedules import crontab
 
 from app.config.settings import get_settings
 from app.core.telemetry import setup_tracing
+from app.utils.chromadb_utils import apply_chromadb_content_type_fix, apply_chromadb_query_fix
 
 # OTel 초기화 — Worker/Beat 프로세스 시작 시 트레이싱 활성화
 # FastAPI 계측(instrument_fastapi_app)은 Worker에 불필요, Celery/httpx만 계측
 setup_tracing()
+
+# chromadb 버그 패치 — Worker 프로세스는 main.py를 실행하지 않으므로 여기서 별도 적용
+# 0.4.x: where_document={} 버그 / 0.5.x: Content-Type 헤더 누락 버그 (Issue #3899)
+apply_chromadb_query_fix()
+apply_chromadb_content_type_fix()
 
 # settings.py에서 설정 로드 (ADR-096: 설정 일관성)
 _settings = get_settings()


### PR DESCRIPTION


## 📌 작업한 내용

Worker 프로세스는 main.py를 거치지 않아 apply_chromadb_content_type_fix()가 미적용 상태였음. celery_app.py에 apply_chromadb_query_fix() + apply_chromadb_content_type_fix() 추가.

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
