### PR TITLE
fix: OTLPSpanExporter endpoint 자동 경로 추가 방식으로 수정

### DIFF
--- a/app/core/telemetry.py
+++ b/app/core/telemetry.py
@@ -60,8 +60,9 @@ def setup_tracing() -> None:
         resource = Resource.create(resource_attrs)
         provider = TracerProvider(resource=resource, sampler=ALWAYS_ON)
 
-        # OTLP HTTP exporter — SDK가 /v1/traces 경로를 자동으로 추가
-        exporter = OTLPSpanExporter(endpoint=endpoint)
+        # OTLP HTTP exporter — OTEL_EXPORTER_OTLP_ENDPOINT env var를 SDK가 직접 읽어
+        # /v1/traces 경로를 자동 추가. endpoint= 명시 시 경로 자동 추가가 동작하지 않음.
+        exporter = OTLPSpanExporter()
         provider.add_span_processor(BatchSpanProcessor(exporter))
 
         trace.set_tracer_provider(provider)


### PR DESCRIPTION
endpoint= 명시 시 /v1/traces 경로가 자동으로 추가되지 않아 404 발생
OTLPSpanExporter()로 변경하여 SDK가 OTEL_EXPORTER_OTLP_ENDPOINT 환경변수 직접 참조

## 📌 작업한 내용

<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

## 🔍 참고 사항

<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷

<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈

<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트

<!-- PR을 제출하기 전에 확인해야 할 항목들 -->

- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인
